### PR TITLE
chore: bump Go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/provabl/ground
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect


### PR DESCRIPTION
Aligns ground's toolchain (was `1.26.2`) with the patched stdlib **go1.26.4**, which fixes the GO-2026-* standard-library advisories ([attest#101](https://github.com/provabl/attest/pull/101) hit these in its govulncheck scan). Keeps the suite's toolchain consistent and pre-empts the same advisories surfacing here.

Verified locally on go1.26.4: `govulncheck` 0 vulns, build ok, tests ok.