### PR TITLE
feat(policies): nitro-attestation SCP — gate data access on runtime attestation (closes #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ## [Unreleased]
 
+### Added
+
+- **`policies/nitro_attestation_scp.json`** — an SCP that denies sensitive-data actions
+  (`s3:GetObject`, `sagemaker:CreateTrainingJob`, …) unless the principal carries
+  `aws:PrincipalTag/attest:nitro-attested == "true"`. The IAM-layer half of the evidence kernel's
+  runtime attestation (the nitro provider produces the verdict; a tag carries it; this SCP gates on
+  it). Tested by `TestNitroAttestationSCPRequiresAttestedTag`. Note: nothing writes the
+  `attest:nitro-attested` tag yet — that attestation-tagging step is future work, mirroring how
+  qualify writes `attest:*` training tags.
+
 ## [0.2.0] - 2026-04-30
 
 ### Added

--- a/policies/nitro_attestation_scp.json
+++ b/policies/nitro_attestation_scp.json
@@ -1,0 +1,23 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyDataAccessWithoutNitroAttestation",
+      "Effect": "Deny",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "sagemaker:CreateTrainingJob",
+        "sagemaker:CreateNotebookInstance",
+        "sagemaker:CreateProcessingJob",
+        "bedrock:InvokeModel"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringNotEquals": {
+          "aws:PrincipalTag/attest:nitro-attested": "true"
+        }
+      }
+    }
+  ]
+}

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -222,6 +222,63 @@ func TestAccountTaggingHasFiveStatements(t *testing.T) {
 	}
 }
 
+// TestNitroAttestationSCPRequiresAttestedTag verifies the nitro-attestation SCP
+// denies sensitive-data actions unless the principal carries
+// aws:PrincipalTag/attest:nitro-attested == "true". This is the IAM-layer half of
+// the evidence kernel's runtime attestation: the nitro provider produces the
+// verdict, a tag carries it, and this SCP gates data access on it.
+func TestNitroAttestationSCPRequiresAttestedTag(t *testing.T) {
+	p := loadPolicy(t, "nitro_attestation_scp.json")
+
+	// Fail-closed: the policy must Deny (never Allow — an Allow would be a no-op).
+	if !p.AllDenyStatements() {
+		t.Error("nitro_attestation_scp must use only Deny statements; an Allow would be a no-op")
+	}
+
+	// The gating condition must be present.
+	if !hasNitroAttestationCondition(p) {
+		t.Error("nitro_attestation_scp must deny on StringNotEquals aws:PrincipalTag/attest:nitro-attested == \"true\"; " +
+			"without it, an unattested principal can access sensitive data")
+	}
+
+	// The sensitive-data actions must be covered by the gated statement.
+	sensitiveActions := []string{
+		"s3:GetObject",
+		"sagemaker:CreateTrainingJob",
+	}
+	for _, action := range sensitiveActions {
+		if !statementDeniesAction(p, action) {
+			t.Errorf("nitro_attestation_scp does not deny %s — unattested data-access path open", action)
+		}
+	}
+}
+
+// hasNitroAttestationCondition returns true if p has a Deny statement whose
+// Condition is StringNotEquals on aws:PrincipalTag/attest:nitro-attested = "true"
+// (deny unless attested — covers both a missing and a non-"true" tag).
+func hasNitroAttestationCondition(p *policy.Policy) bool {
+	const tagKey = "aws:PrincipalTag/attest:nitro-attested"
+	for _, s := range p.Statements {
+		if s.Effect != "Deny" || s.Condition == nil {
+			continue
+		}
+		cond, ok := s.Condition["StringNotEquals"]
+		if !ok {
+			continue
+		}
+		condMap, ok := cond.(map[string]any)
+		if !ok {
+			continue
+		}
+		if val, found := condMap[tagKey]; found {
+			if str, ok := val.(string); ok && str == "true" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // hasSeparateDenyForTag returns true if p has a Deny statement whose
 // Condition references only the given tag in a Null check.
 func hasSeparateDenyForTag(p *policy.Policy, tag string) bool {


### PR DESCRIPTION
Closes #12. Phase-two **Stream B (consumer side)** of [ADR 0001](https://github.com/provabl/provabl/blob/main/docs/adr/0001-evidence-kernel-beneath-cedar.md) — epic hub provabl/evidence#2 — following the nitro provider in **evidence v0.2.0** (evidence#1).

## What this is
The **IAM-layer half** of runtime/enclave attestation. The evidence nitro provider produces a verified `platform.*` verdict; this SCP denies sensitive-data actions unless the principal is attested.

## `policies/nitro_attestation_scp.json`
```json
{
  "Effect": "Deny",
  "Action": ["s3:GetObject", "s3:PutObject", "sagemaker:CreateTrainingJob", "sagemaker:CreateNotebookInstance", "sagemaker:CreateProcessingJob", "bedrock:InvokeModel"],
  "Resource": "*",
  "Condition": { "StringNotEquals": { "aws:PrincipalTag/attest:nitro-attested": "true" } }
}
```
`StringNotEquals` is **fail-closed** — it denies when the tag is missing *or* not `"true"`. The `attest:` namespace matches ground's existing SCPs (`attest:environment-id`, `attest:data-classes`, …) and attest's resolver.

## Design
- **No evidence dependency.** ground is the policy layer; the proof flows in as a principal tag. (Mirrors the #102/#103 boundary: tools produce; ground/attest consume.)
- **New SCP asset, not new role infra.** ground deploys Identity Center permission sets, not workload roles, so a tested `Deny`-unless-attested SCP is the minimal, idiomatic home — consistent with the other `policies/*.json` correctness assets.
- **Tested** by `TestNitroAttestationSCPRequiresAttestedTag` (all-Deny; the `StringNotEquals` condition present; sensitive actions covered) — ground's "every policy is tested before it ships" rule.

## ⚠️ Loop not yet closed end-to-end
Nothing writes the `attest:nitro-attested` principal tag yet — that attestation-tagging step is future work (the same shape as qualify writing `attest:*` training tags). This PR deploys the **condition**; a follow-up will track the tag-writer.

## Verification
`go test ./policies/...` green · `go vet ./...` · `go build ./...` clean.