### PR TITLE
chore: copyright prose → Playground Logic LLC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
   `attest:nitro-attested` tag yet — that attestation-tagging step is future work, mirroring how
   qualify writes `attest:*` training tags.
 
+### Changed
+
+- Copyright holder normalized to Playground Logic LLC.
+
 ## [0.2.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ ground is fully open source (Apache 2.0) with no commercial tier. It is the stru
 
 ## License
 
-Apache 2.0. Copyright 2026 Scott Friedman.
+Apache 2.0. Copyright 2026 Playground Logic LLC.

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -271,7 +271,7 @@ attest:owner            = "pi@mru.edu"              # PI or team contact</code><
         </nav>
       </div>
       <div class="footer-bottom">
-        <span>© 2026 Scott Friedman</span>
+        <span>© 2026 Playground Logic LLC</span>
         <span>Apache 2.0</span>
       </div>
     </footer>

--- a/docs/customizing.html
+++ b/docs/customizing.html
@@ -394,7 +394,7 @@ terraform apply -target=aws_cloudformation_stack.ground_logging \
       </div>
       <div class="footer-bottom">
         <span>Made by <a href="https://github.com/scttfrdmn">@scttfrdmn</a></span>
-        <span>© 2026 Scott Friedman. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache License 2.0</a>.</span>
+        <span>© 2026 Playground Logic LLC. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache License 2.0</a>.</span>
       </div>
     </footer>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -163,7 +163,7 @@ ground deploy</code></pre>
             </div>
             <div class="footer-bottom">
                 <span>Made by <a href="https://github.com/scttfrdmn">@scttfrdmn</a></span>
-                <span>© 2026 Scott Friedman. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache License 2.0</a>.</span>
+                <span>© 2026 Playground Logic LLC. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache License 2.0</a>.</span>
             </div>
         </footer>
     </div>

--- a/docs/integrating.html
+++ b/docs/integrating.html
@@ -207,7 +207,7 @@ aws organizations move-account \
         </nav>
       </div>
       <div class="footer-bottom">
-        <span>© 2026 Scott Friedman</span>
+        <span>© 2026 Playground Logic LLC</span>
         <span>Apache 2.0</span>
       </div>
     </footer>


### PR DESCRIPTION
Sweeps README/docs prose copyright to Playground Logic LLC; records the normalization under `[Unreleased]`. Docs only.