### PR TITLE
feat(policies): AMI-launch gating SCPs (provabl#13, slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **AMI-launch gating SCPs** (provabl#13, slice 1 — the IAM-enforcement / Layer-1 half):
+  - **`policies/ami_launch_gating_scp.json`** — denies `ec2:RunInstances` unless the AMI carries
+    `ec2:ResourceTag/attest:vetted == "true"`. The Deny is scoped to the image ARN
+    (`arn:aws:ec2:*::image/*`) so the tag condition evaluates only against the AMI, not the
+    instance/volumes/ENIs the call also creates (a `Resource:"*"` scope would deny every launch).
+  - **`policies/ami_vetting_lockdown_scp.json`** — denies `ec2:CreateTags`/`ec2:DeleteTags` of the
+    `attest:vetted` key on AMIs for every principal except the designated vetter (an `ArnNotLike`
+    `aws:PrincipalArn` exception). This solves the trust trap — a researcher cannot self-mark an AMI
+    vetted (same "appraised, not asserted" principle as qualify#32's locked `attest:*` tags). The
+    vetter ARN is a deploy-time placeholder (`VETTER_PRINCIPAL_ARN_PLACEHOLDER`) ground/vendor
+    substitutes per account; SCPs cannot parameterize.
+  - Tested by `TestAMILaunchGatingSCPDeniesUnvettedAMIs` and `TestAMIVettingLockdownDeniesTagMutation`
+    (including image-scope and vetter-exception regression guards). The runtime half (an instance
+    proving it booted the vetted image via PCR0) already exists in nitro/nitrotpm; the producer that
+    *writes* `attest:vetted` (vet's AMI vetting) and vendor's per-account deployment are follow-ups.
 - **`policies/nitro_attestation_scp.json`** — an SCP that denies sensitive-data actions
   (`s3:GetObject`, `sagemaker:CreateTrainingJob`, …) unless the principal carries
   `aws:PrincipalTag/attest:nitro-attested == "true"`. The IAM-layer half of the evidence kernel's

--- a/policies/ami_launch_gating_scp.json
+++ b/policies/ami_launch_gating_scp.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyRunInstancesUnlessAMIVetted",
+      "Effect": "Deny",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:*::image/*",
+      "Condition": {
+        "StringNotEquals": {
+          "ec2:ResourceTag/attest:vetted": "true"
+        }
+      }
+    }
+  ]
+}

--- a/policies/ami_vetting_lockdown_scp.json
+++ b/policies/ami_vetting_lockdown_scp.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyVettedTagMutationExceptVetter",
+      "Effect": "Deny",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "arn:aws:ec2:*::image/*",
+      "Condition": {
+        "ForAnyValue:StringEquals": {
+          "aws:TagKeys": [
+            "attest:vetted"
+          ]
+        },
+        "ArnNotLike": {
+          "aws:PrincipalArn": "VETTER_PRINCIPAL_ARN_PLACEHOLDER"
+        }
+      }
+    }
+  ]
+}

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -253,6 +253,181 @@ func TestNitroAttestationSCPRequiresAttestedTag(t *testing.T) {
 	}
 }
 
+// TestAMILaunchGatingSCPDeniesUnvettedAMIs verifies the AMI-launch-gating SCP
+// denies ec2:RunInstances unless the AMI carries ec2:ResourceTag/attest:vetted ==
+// "true" — Layer 1 of the AMI-gating epic (provabl#13). Crucially, the Deny must be
+// scoped to the image resource ARN: a RunInstances call also creates instances,
+// volumes, and ENIs, none of which carry the AMI's tag, so a Resource:"*" scope
+// would evaluate the ResourceTag condition against those and deny every launch.
+func TestAMILaunchGatingSCPDeniesUnvettedAMIs(t *testing.T) {
+	p := loadPolicy(t, "ami_launch_gating_scp.json")
+
+	// Fail-closed: Deny only (an Allow would be a no-op).
+	if !p.AllDenyStatements() {
+		t.Error("ami_launch_gating_scp must use only Deny statements; an Allow would be a no-op")
+	}
+
+	if !statementDeniesAction(p, "ec2:RunInstances") {
+		t.Error("ami_launch_gating_scp does not deny ec2:RunInstances — the AMI launch gate is not active")
+	}
+
+	if !hasResourceTagVettedCondition(p) {
+		t.Error("ami_launch_gating_scp must deny on StringNotEquals ec2:ResourceTag/attest:vetted == \"true\"; " +
+			"without it, an un-vetted AMI can launch")
+	}
+
+	// The gating Deny must scope Resource to the image ARN, not "*".
+	if !deniesScopedToImageResource(p, "ec2:RunInstances") {
+		t.Error("ami_launch_gating_scp RunInstances Deny must scope Resource to the image ARN " +
+			"(arn:aws:ec2:*::image/*); a \"*\" scope evaluates ec2:ResourceTag against the instance/" +
+			"volumes/ENIs the call also creates and would deny every launch")
+	}
+}
+
+// TestAMIVettingLockdownDeniesTagMutation verifies the lockdown SCP denies mutating
+// the attest:vetted tag key on AMIs for everyone except the designated vetter
+// principal — the tamper-resistance behind the launch gate (a researcher must not
+// be able to self-mark an AMI vetted). Same "appraised, not asserted" principle as
+// qualify#32's locked attest:* tags.
+func TestAMIVettingLockdownDeniesTagMutation(t *testing.T) {
+	p := loadPolicy(t, "ami_vetting_lockdown_scp.json")
+
+	if !p.AllDenyStatements() {
+		t.Error("ami_vetting_lockdown_scp must use only Deny statements")
+	}
+
+	for _, action := range []string{"ec2:CreateTags", "ec2:DeleteTags"} {
+		if !statementDeniesAction(p, action) {
+			t.Errorf("ami_vetting_lockdown_scp does not deny %s — the attest:vetted tag could be self-set", action)
+		}
+	}
+
+	// The lockdown must (a) target the attest:vetted tag key and (b) carry a
+	// principal exception — without the key scope it denies all tagging; without
+	// the exception even the vetter can't mark an AMI (the gate would be unusable).
+	if !lockdownTargetsVettedKey(p) {
+		t.Error("ami_vetting_lockdown_scp must scope to aws:TagKeys [attest:vetted]; " +
+			"a broader scope denies all AMI tagging")
+	}
+	if !lockdownHasVetterArnException(p) {
+		t.Error("ami_vetting_lockdown_scp must carry an ArnNotLike aws:PrincipalArn exception for the vetter; " +
+			"without it, no principal (not even the vetter) can set attest:vetted")
+	}
+}
+
+// hasResourceTagVettedCondition returns true if p has a Deny statement whose
+// Condition is StringNotEquals on ec2:ResourceTag/attest:vetted = "true".
+func hasResourceTagVettedCondition(p *policy.Policy) bool {
+	const tagKey = "ec2:ResourceTag/attest:vetted"
+	for _, s := range p.Statements {
+		if s.Effect != "Deny" || s.Condition == nil {
+			continue
+		}
+		cond, ok := s.Condition["StringNotEquals"]
+		if !ok {
+			continue
+		}
+		condMap, ok := cond.(map[string]any)
+		if !ok {
+			continue
+		}
+		if val, found := condMap[tagKey]; found {
+			if str, ok := val.(string); ok && str == "true" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// deniesScopedToImageResource returns true if a Deny statement covering action
+// scopes its Resource to the EC2 image ARN (not "*").
+func deniesScopedToImageResource(p *policy.Policy, action string) bool {
+	const imageARN = "arn:aws:ec2:*::image/*"
+	resourceMatches := func(r any) bool {
+		switch v := r.(type) {
+		case string:
+			return v == imageARN
+		case []any:
+			for _, e := range v {
+				if str, ok := e.(string); ok && str == imageARN {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	actionCovers := func(a any) bool {
+		switch v := a.(type) {
+		case string:
+			return v == action
+		case []any:
+			for _, e := range v {
+				if str, ok := e.(string); ok && str == action {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	for _, s := range p.Statements {
+		if s.Effect == "Deny" && actionCovers(s.Action) && resourceMatches(s.Resource) {
+			return true
+		}
+	}
+	return false
+}
+
+// lockdownTargetsVettedKey returns true if a Deny statement scopes to the
+// attest:vetted tag key via ForAnyValue:StringEquals aws:TagKeys.
+func lockdownTargetsVettedKey(p *policy.Policy) bool {
+	for _, s := range p.Statements {
+		if s.Effect != "Deny" || s.Condition == nil {
+			continue
+		}
+		cond, ok := s.Condition["ForAnyValue:StringEquals"]
+		if !ok {
+			continue
+		}
+		condMap, ok := cond.(map[string]any)
+		if !ok {
+			continue
+		}
+		keys, ok := condMap["aws:TagKeys"]
+		if !ok {
+			continue
+		}
+		if arr, ok := keys.([]any); ok {
+			for _, k := range arr {
+				if str, ok := k.(string); ok && str == "attest:vetted" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// lockdownHasVetterArnException returns true if a Deny statement carries an
+// ArnNotLike condition on aws:PrincipalArn (the vetter-principal carve-out).
+func lockdownHasVetterArnException(p *policy.Policy) bool {
+	for _, s := range p.Statements {
+		if s.Effect != "Deny" || s.Condition == nil {
+			continue
+		}
+		cond, ok := s.Condition["ArnNotLike"]
+		if !ok {
+			continue
+		}
+		if condMap, ok := cond.(map[string]any); ok {
+			if _, found := condMap["aws:PrincipalArn"]; found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // hasNitroAttestationCondition returns true if p has a Deny statement whose
 // Condition is StringNotEquals on aws:PrincipalTag/attest:nitro-attested = "true"
 // (deny unless attested — covers both a missing and a non-"true" tag).


### PR DESCRIPTION
Layer-1 IAM enforcement for the AMI-gating epic (provabl#13): only **vetted** AMIs may launch, and only the **vetter** may mark one vetted. Mirrors the existing nitro SCP pattern; no new deps; unit-tested.

## Two SCPs
- **`ami_launch_gating_scp.json`** — Deny `ec2:RunInstances` unless the AMI carries `ec2:ResourceTag/attest:vetted == "true"`. The Deny is **scoped to the image ARN** (`arn:aws:ec2:*::image/*`) — the one non-obvious correctness point: a `Resource:"*"` scope evaluates the ResourceTag condition against the instance/volumes/ENIs `RunInstances` also creates (none carry the AMI tag) and would deny *every* launch.
- **`ami_vetting_lockdown_scp.json`** — Deny `ec2:CreateTags`/`DeleteTags` of the `attest:vetted` key on AMIs for everyone except the vetter (`ArnNotLike aws:PrincipalArn`). Solves the "trust trap": a researcher can't self-mark an AMI vetted (same "appraised, not asserted" principle as qualify#32's locked `attest:*` tags). The vetter ARN is a deploy-time placeholder ground/vendor substitutes per account (SCPs can't parameterize).

## Tests
Mirror `TestNitroAttestationSCPRequiresAttestedTag`, with **regression guards** for the two failure modes that would silently defeat the gate — the image-scope on the launch gate and the vetter exception on the lockdown. Verified both guards fail when violated and pass when correct.

## Scope
Layer-1 (enforcement) only. The runtime half (an instance proving it booted the vetted image via PCR0) already exists in nitro/nitrotpm. Deferred follow-ups, tracked on the epic: vet writing `attest:vetted` (AMI vetting — carries the golden-PCR0 + CVE-source open questions), and vendor deploying these SCPs into vended accounts.

Refs: provabl#13