### PR TITLE
feat(policies): lock the golden-PCR tags too (provabl#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ## [Unreleased]
 
+### Changed
+
+- **AMI-vetting lockdown SCP now also protects the golden-PCR tags** (provabl#13): `policies/ami_vetting_lockdown_scp.json`
+  extends its `aws:TagKeys` condition (now `ForAnyValue:StringLike`) to cover `attest:pcr*` alongside
+  `attest:vetted`, so only the vetter can write the golden boot-measurement tags `vet ami-reference`
+  records. A forgeable golden PCR would defeat the runtime image binding. Adversarially verified against
+  the live IAM simulator (forging/stripping `attest:pcr0`/`attest:pcr7` → explicitDeny); see
+  `policies/SECURITY.md`.
+
 ### Added
 
 - **`ground preflight`** (provabl#16): verifies the calling principal holds the IAM actions `ground

--- a/policies/SECURITY.md
+++ b/policies/SECURITY.md
@@ -14,7 +14,7 @@ trust boundary they reduce to.
 | Policy | Denies | Unless |
 |---|---|---|
 | `ami_launch_gating_scp.json` | `ec2:RunInstances` (on the image resource) | the AMI carries `ec2:ResourceTag/attest:vetted == "true"` |
-| `ami_vetting_lockdown_scp.json` | `ec2:CreateTags` / `ec2:DeleteTags` of the `attest:vetted` key (on images) | the caller is the designated **vetter** principal (`ArnNotLike aws:PrincipalArn`) |
+| `ami_vetting_lockdown_scp.json` | `ec2:CreateTags` / `ec2:DeleteTags` of the `attest:vetted` key **and the `attest:pcr*` golden-boot-measurement keys** (on images) | the caller is the designated **vetter** principal (`ArnNotLike aws:PrincipalArn`) |
 
 Together: only a **vetted** AMI may launch, and only the **vetter** may mark an AMI
 vetted. The vetter is `vet`'s CI principal (`vet gate ami-… --tag-vetted` writes the
@@ -46,8 +46,9 @@ Verified matrix (all passing):
 |---|---|
 | researcher `CreateTags attest:vetted` on an AMI | **explicitDeny** — self-marking blocked |
 | researcher `DeleteTags attest:vetted` on an AMI | **explicitDeny** — can't strip/rewrite |
-| **vetter** `CreateTags attest:vetted` | allowed — the vetter can mark |
-| researcher `CreateTags` of an unrelated key (`project`) | allowed — lockdown is scoped to the key |
+| researcher `CreateTags`/`DeleteTags` of a golden PCR (`attest:pcr0`, `attest:pcr7`) | **explicitDeny** — a forgeable golden PCR would defeat the runtime image binding |
+| **vetter** `CreateTags attest:vetted` / `attest:pcr0` | allowed — the vetter can mark + record golden PCRs |
+| researcher `CreateTags` of an unrelated key (`project`) | allowed — lockdown is scoped to the keys |
 | `RunInstances` of an AMI tagged `attest:vetted=true` | allowed |
 | `RunInstances` of an AMI tagged `attest:vetted=false` | **explicitDeny** |
 | `RunInstances` of an **untagged** AMI | **explicitDeny** — a missing tag is not "vetted" |

--- a/policies/ami_vetting_lockdown_scp.json
+++ b/policies/ami_vetting_lockdown_scp.json
@@ -10,9 +10,10 @@
       ],
       "Resource": "arn:aws:ec2:*::image/*",
       "Condition": {
-        "ForAnyValue:StringEquals": {
+        "ForAnyValue:StringLike": {
           "aws:TagKeys": [
-            "attest:vetted"
+            "attest:vetted",
+            "attest:pcr*"
           ]
         },
         "ArnNotLike": {

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -302,12 +302,17 @@ func TestAMIVettingLockdownDeniesTagMutation(t *testing.T) {
 		}
 	}
 
-	// The lockdown must (a) target the attest:vetted tag key and (b) carry a
-	// principal exception — without the key scope it denies all tagging; without
-	// the exception even the vetter can't mark an AMI (the gate would be unusable).
-	if !lockdownTargetsVettedKey(p) {
+	// The lockdown must (a) target the attest:vetted tag key AND the attest:pcr*
+	// golden-PCR keys (forging either defeats the gate), and (b) carry a principal
+	// exception — without the key scope it denies all tagging; without the exception
+	// even the vetter can't mark an AMI (the gate would be unusable).
+	if !lockdownTargetsTagKey(p, "attest:vetted") {
 		t.Error("ami_vetting_lockdown_scp must scope to aws:TagKeys [attest:vetted]; " +
 			"a broader scope denies all AMI tagging")
+	}
+	if !lockdownTargetsTagKey(p, "attest:pcr*") {
+		t.Error("ami_vetting_lockdown_scp must also lock the attest:pcr* golden-PCR keys; " +
+			"a forgeable golden PCR would defeat the runtime image binding (provabl#13)")
 	}
 	if !lockdownHasVetterArnException(p) {
 		t.Error("ami_vetting_lockdown_scp must carry an ArnNotLike aws:PrincipalArn exception for the vetter; " +
@@ -378,29 +383,31 @@ func deniesScopedToImageResource(p *policy.Policy, action string) bool {
 	return false
 }
 
-// lockdownTargetsVettedKey returns true if a Deny statement scopes to the
-// attest:vetted tag key via ForAnyValue:StringEquals aws:TagKeys.
-func lockdownTargetsVettedKey(p *policy.Policy) bool {
+// lockdownTargetsTagKey returns true if a Deny statement scopes aws:TagKeys to the
+// given key via a ForAnyValue:StringEquals or ForAnyValue:StringLike condition.
+func lockdownTargetsTagKey(p *policy.Policy, key string) bool {
 	for _, s := range p.Statements {
 		if s.Effect != "Deny" || s.Condition == nil {
 			continue
 		}
-		cond, ok := s.Condition["ForAnyValue:StringEquals"]
-		if !ok {
-			continue
-		}
-		condMap, ok := cond.(map[string]any)
-		if !ok {
-			continue
-		}
-		keys, ok := condMap["aws:TagKeys"]
-		if !ok {
-			continue
-		}
-		if arr, ok := keys.([]any); ok {
-			for _, k := range arr {
-				if str, ok := k.(string); ok && str == "attest:vetted" {
-					return true
+		for _, op := range []string{"ForAnyValue:StringEquals", "ForAnyValue:StringLike"} {
+			cond, ok := s.Condition[op]
+			if !ok {
+				continue
+			}
+			condMap, ok := cond.(map[string]any)
+			if !ok {
+				continue
+			}
+			keys, ok := condMap["aws:TagKeys"]
+			if !ok {
+				continue
+			}
+			if arr, ok := keys.([]any); ok {
+				for _, k := range arr {
+					if str, ok := k.(string); ok && str == key {
+						return true
+					}
 				}
 			}
 		}

--- a/policies/scp_simulate_test.go
+++ b/policies/scp_simulate_test.go
@@ -107,7 +107,11 @@ func TestLockdownSCP_BlocksTagForgery(t *testing.T) {
 	}{
 		{"researcher forges attest:vetted (CreateTags)", "ec2:CreateTags", researcherID, []string{"attest:vetted"}, true},
 		{"researcher strips attest:vetted (DeleteTags)", "ec2:DeleteTags", researcherID, []string{"attest:vetted"}, true},
+		{"researcher forges golden PCR attest:pcr0", "ec2:CreateTags", researcherID, []string{"attest:pcr0"}, true},
+		{"researcher forges golden PCR attest:pcr7", "ec2:CreateTags", researcherID, []string{"attest:pcr7"}, true},
+		{"researcher strips a golden PCR (DeleteTags)", "ec2:DeleteTags", researcherID, []string{"attest:pcr0"}, true},
 		{"vetter sets attest:vetted (CreateTags)", "ec2:CreateTags", vetterARN, []string{"attest:vetted"}, false},
+		{"vetter sets a golden PCR attest:pcr0", "ec2:CreateTags", vetterARN, []string{"attest:pcr0"}, false},
 		{"researcher sets an unrelated tag (project)", "ec2:CreateTags", researcherID, []string{"project"}, false},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
The runtime image binding records a vetted AMI's known-good boot PCR as `attest:pcr<N>` tags (via `vet ami-reference`). A forgeable golden PCR defeats the binding, so the lockdown SCP now protects those keys like `attest:vetted`.

- **`ami_vetting_lockdown_scp.json`**: `ForAnyValue:StringEquals` → `StringLike` on `aws:TagKeys`, covering `[attest:vetted, attest:pcr*]`; vetter `ArnNotLike` carve-out unchanged.
- **Tests**: structural (lockdown targets both keys) + **awssim adversarial** — non-vetter forging/stripping `attest:pcr0`/`attest:pcr7` → `explicitDeny`, vetter allowed, unrelated key allowed. **Proven against the live IAM simulator** (the wildcard actually denies — not assumed).
- SECURITY.md updated.

Refs: provabl#13