### PR TITLE
feat: compute-to-data endpoint declarations + egress-gating SCP (ground#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **Compute-to-data endpoint declarations + egress-gating SCP** (provabl/ground#10; provabl#11 Tier 2,
+  ADR 0002 Decision 3). `NetworkConfig.data_endpoints` declares external research-data endpoints an SRE
+  may reach in-place (NIH dbGaP S3, AnVIL/Terra) — name, url, required `data_class`, `sre_types`,
+  `authorized_ous`. `policies/data_endpoint_access_scp.json` is the **coarse outer gate**: it denies the
+  in-place data-access actions (`s3:GetObject`/`ListBucket`, `sagemaker:Create{Training,Processing}Job`)
+  unless the principal carries an `attest:data-classes` posture tag (a `Null` check, so it never trips on
+  the multi-valued tag's contents). `ground export-metadata` now emits declared endpoints in
+  `ground-meta.json` for `attest init`. The **fine** per-DUA/per-dataset decision is attest's
+  dataset-scoped Cedar policy (attest#100) — same two-layer model as AMI gating (provabl#13). Tested by
+  `TestDataEndpointAccessSCPRequiresDataClassPosture` (Deny-only, posture condition present, egress
+  actions covered). **The VPC-routing half — `internal/stack/network` is still a stub — is a follow-up;
+  this is the policy + config + metadata surface, not the routing implementation.**
 - **`ground preflight`** (provabl#16): verifies the calling principal holds the IAM actions `ground
   deploy` needs (Organizations create/attach/describe, CloudFormation create/update/describe, the
   `CAPABILITY_NAMED_IAM` create actions) via read-only `iam:SimulatePrincipalPolicy` against the

--- a/cmd/ground/main.go
+++ b/cmd/ground/main.go
@@ -419,6 +419,10 @@ type GroundMeta struct {
 	// ExternalServices records non-AWS services declared in ground.yaml.
 	// attest uses this to assess controls satisfied by those services.
 	ExternalServices []config.ExternalService `json:"external_services,omitempty"`
+	// DataEndpoints records external research-data endpoints declared for
+	// compute-to-data access (provabl/ground#10). attest reads these to know which
+	// in-place datasets the SRE may reach, alongside its dataset-scoped Cedar policy.
+	DataEndpoints []config.DataEndpoint `json:"data_endpoints,omitempty"`
 	// ProbeResults records verification results from ground-probe-* binaries.
 	// Keyed by service name. nil value = no probe configured for that service.
 	ProbeResults map[string]*probe.ProbeResult `json:"probe_results,omitempty"`
@@ -463,6 +467,7 @@ func runExportMetadata(region, configPath, outputPath string) error {
 	// Load config to capture external service declarations and run any configured probes.
 	if cfg, cfgErr := config.Load(configPath); cfgErr == nil {
 		meta.ExternalServices = cfg.Security.ExternalServices
+		meta.DataEndpoints = cfg.Network.DataEndpoints
 		// Run probes for services that have one configured.
 		if len(cfg.Security.ExternalServices) > 0 {
 			probeResults := probe.RunAll(ctx, cfg.Security.ExternalServices)
@@ -511,6 +516,7 @@ func runExportMetadata(region, configPath, outputPath string) error {
 	fmt.Printf("  CloudTrail:          %v\n", meta.CloudTrailEnabled)
 	fmt.Printf("  Config:              %v\n", meta.ConfigEnabled)
 	fmt.Printf("  External services:   %d declared\n", len(meta.ExternalServices))
+	fmt.Printf("  Data endpoints:      %d declared\n", len(meta.DataEndpoints))
 	for _, svc := range meta.ExternalServices {
 		if r, ok := meta.ProbeResults[svc.Name]; ok && r != nil {
 			if r.Error != "" {

--- a/ground.example.yaml
+++ b/ground.example.yaml
@@ -24,6 +24,23 @@ network:
     - kms
     - logs
 
+  # External research-data endpoints reachable in-place (compute-to-data: the SRE
+  # gets network access to the dataset at its source; data never moves into the
+  # SRE). Declaring an endpoint lets ground render the egress-gating SCP
+  # (data_endpoint_access_scp — denies these actions unless the account carries an
+  # attest:data-classes posture tag) and export the endpoint in ground-meta for
+  # attest, whose dataset-scoped Cedar policy makes the fine per-DUA/per-dataset
+  # decision (provabl ADR 0002, ground#10). The VPC-routing half (the network
+  # stack) is a follow-up — this is the policy/metadata surface.
+  data_endpoints:
+    - name: ncbi-dbgap
+      vendor: NCBI dbGaP
+      url: s3.amazonaws.com
+      data_class: GENOMIC
+      sre_types: [nih-genomics]
+      authorized_ous: [SensitiveResearch/NIHGenomic]
+      notes: "Controlled-access genomic data. Per-DUA access enforced by attest's Cedar policy."
+
 identity:
   identity_center: true
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,18 +21,40 @@ type Config struct {
 }
 
 type OrgConfig struct {
-	Name          string   `yaml:"name"`
-	Region        string   `yaml:"region"`
-	ManagementID  string   `yaml:"management_account_id"`
-	AuditEmail    string   `yaml:"audit_email"`
-	LoggingEmail  string   `yaml:"logging_email"`
-	WorkloadOUs   []string `yaml:"workload_ous"`
+	Name         string   `yaml:"name"`
+	Region       string   `yaml:"region"`
+	ManagementID string   `yaml:"management_account_id"`
+	AuditEmail   string   `yaml:"audit_email"`
+	LoggingEmail string   `yaml:"logging_email"`
+	WorkloadOUs  []string `yaml:"workload_ous"`
 }
 
 type NetworkConfig struct {
-	TransitGateway bool   `yaml:"transit_gateway"`
-	CIDRBlock      string `yaml:"cidr_block"`
+	TransitGateway bool     `yaml:"transit_gateway"`
+	CIDRBlock      string   `yaml:"cidr_block"`
 	VPCEndpoints   []string `yaml:"vpc_endpoints"`
+	// DataEndpoints declares external research-data endpoints an SRE may reach
+	// in-place (compute-to-data: NIH dbGaP S3, AnVIL/Terra, …). Each is gated on
+	// compliance posture; see the compute-to-data design (provabl ADR 0002) and
+	// provabl/ground#10. Declaring them here lets ground (a) render the egress-
+	// gating SCP and (b) export them in ground-meta for attest. The VPC-routing
+	// half (the network stack) is a follow-up — these declarations are the
+	// policy/metadata surface, not the routing implementation.
+	DataEndpoints []DataEndpoint `yaml:"data_endpoints,omitempty"`
+}
+
+// DataEndpoint is an external research-data endpoint reachable under the
+// compute-to-data model. Access is gated coarsely by ground's SCP (on the
+// account's data-class posture) and finely by attest's dataset-scoped Cedar
+// policy (per-DUA, per-dataset). The two layers mirror AMI gating (provabl#13).
+type DataEndpoint struct {
+	Name          string   `yaml:"name"`                     // slug, e.g. "ncbi-dbgap"
+	Vendor        string   `yaml:"vendor,omitempty"`         // display name, e.g. "NCBI dbGaP"
+	URL           string   `yaml:"url"`                      // endpoint host/ARN the SRE routes to
+	DataClass     string   `yaml:"data_class"`               // required posture, e.g. "GENOMIC" — matched against attest:data-classes
+	SRETypes      []string `yaml:"sre_types,omitempty"`      // SRE types permitted to reach it, e.g. [nih-genomics]
+	AuthorizedOUs []string `yaml:"authorized_ous,omitempty"` // OU paths permitted, e.g. [SensitiveResearch/NIHGenomic]
+	Notes         string   `yaml:"notes,omitempty"`
 }
 
 type IdentityConfig struct {
@@ -63,12 +85,12 @@ type SecurityConfig struct {
 // Category options: edr, siem, cspm, cwpp, data-transfer, vuln-scanning, identity, research-platform
 // Feature options: fedramp-high, fedramp-moderate, baa, hipaa-compliant, high-assurance, soc2-type2, iso27001
 type ExternalService struct {
-	Name        string         `yaml:"name"`               // slug, e.g., "crowdstrike-falcon"
-	Vendor      string         `yaml:"vendor"`             // display name, e.g., "CrowdStrike"
-	Category    string         `yaml:"category"`           // edr, siem, cspm, data-transfer, ...
-	Features    []string       `yaml:"features,omitempty"` // fedramp-high, baa, high-assurance, ...
-	Scope       []string       `yaml:"scope,omitempty"`    // OU names; empty = org-wide
-	Notes       string         `yaml:"notes,omitempty"`    // free-text operator context
+	Name     string   `yaml:"name"`               // slug, e.g., "crowdstrike-falcon"
+	Vendor   string   `yaml:"vendor"`             // display name, e.g., "CrowdStrike"
+	Category string   `yaml:"category"`           // edr, siem, cspm, data-transfer, ...
+	Features []string `yaml:"features,omitempty"` // fedramp-high, baa, high-assurance, ...
+	Scope    []string `yaml:"scope,omitempty"`    // OU names; empty = org-wide
+	Notes    string   `yaml:"notes,omitempty"`    // free-text operator context
 	// Probe is the name or path of a ground-probe-* binary that verifies this service's
 	// declarations via its API. Optional — if absent, declarations are used as-is.
 	// The probe binary receives ProbeConfig as JSON on stdin and writes a ProbeResult to stdout.

--- a/policies/data_endpoint_access_scp.json
+++ b/policies/data_endpoint_access_scp.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyComputeToDataEgressWithoutDataClassPosture",
+      "Effect": "Deny",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket",
+        "sagemaker:CreateTrainingJob",
+        "sagemaker:CreateProcessingJob"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:PrincipalTag/attest:data-classes": "true"
+        }
+      }
+    }
+  ]
+}

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -461,6 +461,60 @@ func hasNitroAttestationCondition(p *policy.Policy) bool {
 	return false
 }
 
+// TestDataEndpointAccessSCPRequiresDataClassPosture verifies the compute-to-data
+// egress gate (provabl/ground#10; provabl ADR 0002). It must deny the in-place
+// data-access actions unless the principal carries the attest:data-classes posture
+// tag — the coarse outer gate. The fine, per-DUA/per-dataset decision is attest's
+// dataset-scoped Cedar policy (attest#100); this SCP only asks "may this account
+// class reach external research data at all?".
+func TestDataEndpointAccessSCPRequiresDataClassPosture(t *testing.T) {
+	p := loadPolicy(t, "data_endpoint_access_scp.json")
+
+	// Fail-closed: Deny only (an Allow would be a no-op SCP).
+	if !p.AllDenyStatements() {
+		t.Error("data_endpoint_access_scp must use only Deny statements; an Allow would be a no-op")
+	}
+
+	// The gating condition: deny when the data-class posture tag is absent.
+	if !hasPrincipalTagNullCondition(p, "attest:data-classes") {
+		t.Error("data_endpoint_access_scp must deny on Null aws:PrincipalTag/attest:data-classes == \"true\"; " +
+			"without it, a principal lacking any data-class posture can reach external research data")
+	}
+
+	// The compute-to-data egress actions must be covered.
+	for _, action := range []string{"s3:GetObject", "sagemaker:CreateTrainingJob"} {
+		if !statementDeniesAction(p, action) {
+			t.Errorf("data_endpoint_access_scp does not deny %s — un-postured egress path open", action)
+		}
+	}
+}
+
+// hasPrincipalTagNullCondition returns true if p has a Deny statement whose
+// Condition is a Null check on aws:PrincipalTag/<tag> == "true" (deny unless the
+// principal carries the tag).
+func hasPrincipalTagNullCondition(p *policy.Policy, tag string) bool {
+	tagKey := "aws:PrincipalTag/" + tag
+	for _, s := range p.Statements {
+		if s.Effect != "Deny" || s.Condition == nil {
+			continue
+		}
+		nullCond, ok := s.Condition["Null"]
+		if !ok {
+			continue
+		}
+		condMap, ok := nullCond.(map[string]any)
+		if !ok {
+			continue
+		}
+		if val, found := condMap[tagKey]; found {
+			if str, ok := val.(string); ok && str == "true" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // hasSeparateDenyForTag returns true if p has a Deny statement whose
 // Condition references only the given tag in a Null check.
 func hasSeparateDenyForTag(p *policy.Policy, tag string) bool {


### PR DESCRIPTION
The coarse network/posture half of compute-to-data (provabl#11 Tier 2; ADR 0002 **Decision 3**). Pairs with attest#100's dataset-scoped Cedar gate to complete the chain.

## What
- **`NetworkConfig.data_endpoints`** — declare external research-data endpoints the SRE reaches in-place (NIH dbGaP S3, AnVIL/Terra): `name`, `url`, required `data_class`, `sre_types`, `authorized_ous`.
- **`policies/data_endpoint_access_scp.json`** — the **coarse outer gate**: denies the in-place data-access actions (`s3:GetObject`/`ListBucket`, `sagemaker:Create{Training,Processing}Job`) unless the principal carries an `attest:data-classes` posture tag.
- **`ground export-metadata`** — emits declared endpoints in `ground-meta.json` for `attest init`.

## Two layers, mirroring AMI gating (provabl#13)
| Layer | This PR / attest#100 | Question | Granularity |
|---|---|---|---|
| ground SCP | `data_endpoint_access_scp` | may this *account class* reach external research data at all? | coarse (posture tag) |
| attest Cedar | `cedar-nih-approved-user` | may this *researcher* read *this dataset* with *their DUA*? | fine (per-DUA, per-dataset) |

## A subtlety worth calling out
The condition is a **`Null` check**, not `StringNotEquals`. `attest:data-classes` is multi-valued (e.g. `"CUI,GENOMIC"`), so an equality test would wrongly deny a legitimately multi-class principal. The honest coarse gate is "posture tag present at all"; the specific class→dataset binding is attest's Cedar layer.

## Honest scope (flagged in the ADR + the epic)
**The VPC-routing half is NOT here** — `internal/stack/network` is still a stub. This PR is the **policy + config + metadata** surface; wiring actual VPC routes to the declared endpoints is a follow-up. I scoped this deliberately as the slice that lands independently.

Tested by `TestDataEndpointAccessSCPRequiresDataClassPosture` (Deny-only, posture condition present, egress actions covered); full ground suite passes (0 failures). Refs: provabl#11, ground#10.