### PR TITLE
feat(network): deterministic CIDR allocator (ADR 0001 step 1, ground#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **Deterministic CIDR allocator** (`internal/stack/network/cidr.go`) — build step 1 of ADR 0001. A
+  pure function from the supernet (`NetworkConfig.CIDRBlock`) + the ordered tier list to a hub `/16`
+  (index 0) plus one `/16` per spoke tier, each split into per-AZ `/20` subnets. Allocation is a stable
+  function of `(supernet, tier index)` with no time or randomness, so re-running `ground deploy` never
+  renumbers an existing spoke (renumbering is destructive) — guarded by a test that appends a tier and
+  asserts existing spokes keep their blocks. Validates supernet size (must hold 1 hub + N spokes), AZ
+  count (1–16 `/20`s per `/16`), and rejects empty/duplicate tier names. No AWS calls; unit-tested like
+  the SCPs. (provabl/ground#10)
 - **ADR 0001 — network foundation** (`docs/adr/0001-network-foundation.md`): design for the
   `internal/stack/network` stub and the routing half of provabl/ground#10. Decides a hub-and-spoke
   topology (shared-services hub holding centralized org-conditioned interface endpoints; per-tier spoke

--- a/internal/stack/network/cidr.go
+++ b/internal/stack/network/cidr.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package network builds ground's network-foundation CloudFormation stack:
+// a hub-and-spoke topology with org-conditioned VPC endpoints and compute-to-data
+// egress. See docs/adr/0001-network-foundation.md.
+//
+// This file is the deterministic CIDR allocator (ADR 0001, build step 1): a pure
+// function from the supernet + the ordered tier list to per-VPC /16 blocks and
+// per-AZ /20 subnets. Determinism is the point — re-running ground deploy must
+// never renumber an existing spoke (renumbering is destructive), so allocation is
+// a stable function of (supernet, tier index), with no time or randomness.
+package network
+
+import (
+	"fmt"
+	"net/netip"
+)
+
+// Allocation prefix lengths (ADR 0001): each VPC is a /16 carved from the
+// supernet; each per-AZ private subnet is a /20 carved from its VPC.
+const (
+	vpcPrefixLen    = 16
+	subnetPrefixLen = 20
+	maxAZs          = 1 << (subnetPrefixLen - vpcPrefixLen) // /20s per /16 = 16
+)
+
+// VPCAlloc is one VPC's address allocation: its /16 and the per-AZ /20 subnets.
+type VPCAlloc struct {
+	Name    string         // "hub", or a spoke tier name ("Research", …)
+	CIDR    netip.Prefix   // the /16
+	Subnets []netip.Prefix // one /20 per AZ, in order
+}
+
+// Plan is the full deterministic allocation: the hub plus one spoke per tier,
+// each carved from Supernet in a stable order.
+type Plan struct {
+	Supernet netip.Prefix
+	Hub      VPCAlloc
+	Spokes   []VPCAlloc
+}
+
+// Allocate carves supernetCIDR into a hub /16 (index 0) followed by one /16 per
+// spoke tier, in the order given, each split into azCount /20 subnets. The order
+// of spokeTiers is the allocation order and MUST be stable across runs (pass the
+// OU tier list in a fixed order); spoke N always lands on the same /16.
+//
+// Pure and deterministic: no time, no randomness, no AWS. Errors on a malformed
+// supernet, a supernet too small to hold 1 hub + len(spokeTiers) /16s, an azCount
+// outside 1..16, or a duplicate/empty tier name.
+func Allocate(supernetCIDR string, spokeTiers []string, azCount int) (*Plan, error) {
+	supernet, err := netip.ParsePrefix(supernetCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("parse supernet %q: %w", supernetCIDR, err)
+	}
+	supernet = supernet.Masked()
+	if !supernet.Addr().Is4() {
+		return nil, fmt.Errorf("supernet %q must be IPv4 (AWS VPC primary CIDR is IPv4)", supernetCIDR)
+	}
+	if supernet.Bits() > vpcPrefixLen {
+		return nil, fmt.Errorf("supernet %q is /%d — must be /%d or larger to carve /%d VPCs",
+			supernetCIDR, supernet.Bits(), vpcPrefixLen, vpcPrefixLen)
+	}
+	if azCount < 1 || azCount > maxAZs {
+		return nil, fmt.Errorf("azCount %d out of range (1..%d /20 subnets fit in a /16)", azCount, maxAZs)
+	}
+
+	available := 1 << (vpcPrefixLen - supernet.Bits()) // number of /16s in the supernet
+	need := 1 + len(spokeTiers)                        // hub + spokes
+	if need > available {
+		return nil, fmt.Errorf("supernet /%d holds %d /%d VPCs but %d are needed (1 hub + %d spokes)",
+			supernet.Bits(), available, vpcPrefixLen, need, len(spokeTiers))
+	}
+
+	seen := map[string]bool{}
+	for _, t := range spokeTiers {
+		if t == "" {
+			return nil, fmt.Errorf("spoke tier name must not be empty")
+		}
+		if seen[t] {
+			return nil, fmt.Errorf("duplicate spoke tier %q", t)
+		}
+		seen[t] = true
+	}
+
+	hub, err := vpcAlloc(supernet, "hub", 0, azCount)
+	if err != nil {
+		return nil, err
+	}
+	plan := &Plan{Supernet: supernet, Hub: hub}
+	for i, tier := range spokeTiers {
+		sp, err := vpcAlloc(supernet, tier, i+1, azCount) // hub is index 0
+		if err != nil {
+			return nil, err
+		}
+		plan.Spokes = append(plan.Spokes, sp)
+	}
+	return plan, nil
+}
+
+// vpcAlloc carves the index-th /16 from supernet and splits it into azCount /20s.
+func vpcAlloc(supernet netip.Prefix, name string, index, azCount int) (VPCAlloc, error) {
+	cidr, err := nthSubnet(supernet, vpcPrefixLen, index)
+	if err != nil {
+		return VPCAlloc{}, fmt.Errorf("allocate /%d for %q: %w", vpcPrefixLen, name, err)
+	}
+	subnets := make([]netip.Prefix, 0, azCount)
+	for az := 0; az < azCount; az++ {
+		sub, err := nthSubnet(cidr, subnetPrefixLen, az)
+		if err != nil {
+			return VPCAlloc{}, fmt.Errorf("allocate /%d subnet %d for %q: %w", subnetPrefixLen, az, name, err)
+		}
+		subnets = append(subnets, sub)
+	}
+	return VPCAlloc{Name: name, CIDR: cidr, Subnets: subnets}, nil
+}
+
+// nthSubnet returns the index-th subnet of length newPrefixLen carved from base.
+// E.g. nthSubnet(10.0.0.0/8, 16, 3) == 10.3.0.0/16. IPv4 only.
+func nthSubnet(base netip.Prefix, newPrefixLen, index int) (netip.Prefix, error) {
+	if newPrefixLen < base.Bits() || newPrefixLen > 32 {
+		return netip.Prefix{}, fmt.Errorf("new prefix /%d invalid for base /%d", newPrefixLen, base.Bits())
+	}
+	subnetBits := newPrefixLen - base.Bits()
+	if index < 0 || index >= (1<<subnetBits) {
+		return netip.Prefix{}, fmt.Errorf("index %d out of range for %d subnet bits", index, subnetBits)
+	}
+	baseInt := addrToUint32(base.Addr())
+	step := uint32(1) << (32 - newPrefixLen)
+	addr := uint32ToAddr(baseInt + uint32(index)*step)
+	return netip.PrefixFrom(addr, newPrefixLen), nil
+}
+
+func addrToUint32(a netip.Addr) uint32 {
+	b := a.As4()
+	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+}
+
+func uint32ToAddr(v uint32) netip.Addr {
+	return netip.AddrFrom4([4]byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)})
+}

--- a/internal/stack/network/cidr_test.go
+++ b/internal/stack/network/cidr_test.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package network
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The OU tiers in their fixed allocation order (matches internal/stack/accounts).
+var tiers = []string{"Infrastructure", "Research", "SensitiveResearch", "DoD-CMMC"}
+
+func TestAllocate_CarvesExpectedBlocks(t *testing.T) {
+	plan, err := Allocate("10.0.0.0/8", tiers, 3)
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+
+	// Hub is index 0 → first /16.
+	if got := plan.Hub.CIDR.String(); got != "10.0.0.0/16" {
+		t.Errorf("hub CIDR = %s, want 10.0.0.0/16", got)
+	}
+	if plan.Hub.Name != "hub" {
+		t.Errorf("hub name = %q, want hub", plan.Hub.Name)
+	}
+
+	// Spokes follow in order: 10.1/16, 10.2/16, 10.3/16, 10.4/16.
+	wantSpoke := map[string]string{
+		"Infrastructure":    "10.1.0.0/16",
+		"Research":          "10.2.0.0/16",
+		"SensitiveResearch": "10.3.0.0/16",
+		"DoD-CMMC":          "10.4.0.0/16",
+	}
+	if len(plan.Spokes) != len(tiers) {
+		t.Fatalf("got %d spokes, want %d", len(plan.Spokes), len(tiers))
+	}
+	for _, sp := range plan.Spokes {
+		if got := sp.CIDR.String(); got != wantSpoke[sp.Name] {
+			t.Errorf("spoke %s CIDR = %s, want %s", sp.Name, got, wantSpoke[sp.Name])
+		}
+	}
+
+	// Per-AZ /20 subnets of the hub: 10.0.0.0/20, 10.0.16.0/20, 10.0.32.0/20.
+	wantHubSubnets := []string{"10.0.0.0/20", "10.0.16.0/20", "10.0.32.0/20"}
+	var gotHubSubnets []string
+	for _, s := range plan.Hub.Subnets {
+		gotHubSubnets = append(gotHubSubnets, s.String())
+	}
+	if !reflect.DeepEqual(gotHubSubnets, wantHubSubnets) {
+		t.Errorf("hub subnets = %v, want %v", gotHubSubnets, wantHubSubnets)
+	}
+}
+
+func TestAllocate_Deterministic(t *testing.T) {
+	a, err := Allocate("10.0.0.0/8", tiers, 3)
+	if err != nil {
+		t.Fatalf("Allocate a: %v", err)
+	}
+	b, err := Allocate("10.0.0.0/8", tiers, 3)
+	if err != nil {
+		t.Fatalf("Allocate b: %v", err)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Error("Allocate is not deterministic: two calls produced different plans")
+	}
+}
+
+// Appending a tier must not renumber the existing spokes — the destructive case
+// the determinism guarantee exists to prevent.
+func TestAllocate_AppendTierDoesNotRenumber(t *testing.T) {
+	before, _ := Allocate("10.0.0.0/8", tiers, 3)
+	after, _ := Allocate("10.0.0.0/8", append(append([]string{}, tiers...), "NewTier"), 3)
+
+	beforeByName := map[string]string{}
+	for _, sp := range before.Spokes {
+		beforeByName[sp.Name] = sp.CIDR.String()
+	}
+	for _, sp := range after.Spokes {
+		if was, existed := beforeByName[sp.Name]; existed && was != sp.CIDR.String() {
+			t.Errorf("spoke %s renumbered: was %s, now %s", sp.Name, was, sp.CIDR.String())
+		}
+	}
+}
+
+func TestAllocate_SmallSupernet(t *testing.T) {
+	// A /14 holds four /16s: hub + 3 spokes fits exactly.
+	plan, err := Allocate("172.16.0.0/14", []string{"a", "b", "c"}, 2)
+	if err != nil {
+		t.Fatalf("Allocate /14 with 3 spokes: %v", err)
+	}
+	if plan.Hub.CIDR.String() != "172.16.0.0/16" {
+		t.Errorf("hub = %s, want 172.16.0.0/16", plan.Hub.CIDR)
+	}
+	if got := plan.Spokes[2].CIDR.String(); got != "172.19.0.0/16" {
+		t.Errorf("third spoke = %s, want 172.19.0.0/16", got)
+	}
+}
+
+func TestAllocate_Errors(t *testing.T) {
+	cases := []struct {
+		name     string
+		supernet string
+		tiers    []string
+		az       int
+	}{
+		{"malformed supernet", "not-a-cidr", tiers, 3},
+		{"supernet smaller than /16", "10.0.0.0/17", tiers, 3},
+		{"supernet too small for tiers", "10.0.0.0/16", tiers, 3}, // /16 = 1 VPC, need 5
+		{"too few AZs", "10.0.0.0/8", tiers, 0},
+		{"too many AZs", "10.0.0.0/8", tiers, 17},
+		{"empty tier name", "10.0.0.0/8", []string{"a", ""}, 3},
+		{"duplicate tier", "10.0.0.0/8", []string{"a", "a"}, 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Allocate(tc.supernet, tc.tiers, tc.az); err == nil {
+				t.Errorf("%s: want error, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestAllocate_NoSpokes(t *testing.T) {
+	// Hub-only (TransitGateway:false degrade path uses a single VPC, but the
+	// allocator must still handle zero spokes cleanly).
+	plan, err := Allocate("10.0.0.0/8", nil, 3)
+	if err != nil {
+		t.Fatalf("Allocate hub-only: %v", err)
+	}
+	if len(plan.Spokes) != 0 {
+		t.Errorf("got %d spokes, want 0", len(plan.Spokes))
+	}
+	if plan.Hub.CIDR.String() != "10.0.0.0/16" {
+		t.Errorf("hub = %s, want 10.0.0.0/16", plan.Hub.CIDR)
+	}
+}


### PR DESCRIPTION
Build **step 1** of ground's network foundation (ground `docs/adr/0001-network-foundation.md`). The pure, AWS-free core the rest of the stack builds on.

## What
`Allocate(supernetCIDR, spokeTiers, azCount)` → a `Plan`: a **hub /16** (index 0) plus one **/16 per spoke tier** in the given order, each split into per-AZ **/20** subnets.

## The property that matters
Allocation is a **stable function of `(supernet, tier index)`** — no time, no randomness, no AWS. Re-running `ground deploy` must never renumber an existing spoke (CIDR renumbering is destructive). `TestAllocate_AppendTierDoesNotRenumber` appends a tier and asserts every existing spoke keeps its block.

## Details
- `net/netip`-based subnet carving (`nthSubnet`: e.g. `10.0.0.0/8` index 3 → `10.3.0.0/16`).
- Validates: supernet must be IPv4 `/16` or larger and hold `1 hub + len(tiers)` /16s; `azCount` 1–16 (/20s per /16); no empty/duplicate tier names.
- Unit-tested like the SCPs — pure, no live calls: exact carve (hub `10.0.0.0/16`, spokes `10.1–10.4/16`, hub subnets `10.0.0.0/20`,`10.0.16.0/20`,`10.0.32.0/20`), determinism, no-renumber, a tight `/14` supernet, hub-only, and all seven error paths.

Next steps per ADR 0001: single-VPC template → hub-and-spoke+TGW → compute-to-data egress (ground#10 routing). Refs: provabl#11, provabl/ground#10.