### PR TITLE
feat(network): hub-and-spoke + segregated Transit Gateway (ADR 0001 step 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **Network foundation: hub-and-spoke + Transit Gateway** (`internal/stack/network/network.go`) — build
+  step 3 of ADR 0001. When `network.transit_gateway` is set and `org.workload_ous` lists tiers,
+  `Template()` now builds a shared **hub** VPC (holding the centralized gateway + org-conditioned
+  interface endpoints), one private **spoke** VPC per workload tier, and a **Transit Gateway** joining
+  them with **segregated per-tier route tables**: each spoke's TGW route table carries a route to the
+  hub (for the shared endpoints) but **none to sibling spokes**, so cross-tier traffic has no path —
+  the `ground:tier`/`attest:data-classes` isolation becomes a routing fact, not just a tag. The TGW
+  disables default route-table association/propagation (a new attachment must not silently join a
+  shared table). Falls back to the single-VPC path (step 2) when TGW is off or no tiers are declared.
+  Unit-tested as template data, including the **no-cross-spoke-route invariant** and the
+  default-table-disable guard; verified via `--dry-run`. (provabl/ground#10)
 - **Network foundation: single-VPC stack** (`internal/stack/network/network.go`) — build step 2 of
   ADR 0001 (the `TransitGateway:false` degrade path). `network.Stack.Template()` emits a private-only
   VPC (no Internet Gateway) on the deterministic hub `/16`, one private `/20` subnet per AZ (3 by

--- a/internal/stack/network/network.go
+++ b/internal/stack/network/network.go
@@ -48,16 +48,34 @@ func New(cfg *config.NetworkConfig, org *config.OrgConfig) *Stack {
 // StackName returns the CloudFormation stack name.
 func (s *Stack) StackName() string { return "ground-network" }
 
-// Template generates the single-VPC network foundation. The VPC CIDR is the hub
-// /16 of the deterministic allocation (ADR 0001 step 1) carved from
-// NetworkConfig.CIDRBlock; private subnets are its per-AZ /20s.
+// Template generates the network foundation. When NetworkConfig.TransitGateway is
+// set and there are workload tiers to spoke out, it builds the hub-and-spoke
+// topology (ADR 0001 step 3); otherwise it builds the single self-contained VPC
+// (step 2, the degrade path). Both carve CIDRs from the deterministic allocation
+// (step 1) over NetworkConfig.CIDRBlock.
 func (s *Stack) Template() (*cfn.Template, error) {
 	supernet := s.cfg.CIDRBlock
 	if supernet == "" {
 		supernet = "10.0.0.0/8"
 	}
-	// Step 2 deploys a single self-contained VPC (no spokes); it occupies the hub
-	// /16. The hub-and-spoke fan-out is step 3.
+	tiers := spokeTiers(s.org.WorkloadOUs)
+	if s.cfg.TransitGateway && len(tiers) > 0 {
+		return s.hubSpokeTemplate(supernet, tiers)
+	}
+	return s.singleVPCTemplate(supernet)
+}
+
+// spokeTiers normalizes the workload OU list into spoke tier names, dropping
+// empties and de-duping (the allocator rejects either, but normalizing here keeps
+// the topology decision in one place).
+func spokeTiers(workloadOUs []string) []string {
+	return sortedUnique(workloadOUs)
+}
+
+// singleVPCTemplate is the TransitGateway:false degrade path (ADR 0001 step 2): a
+// single private VPC on the hub /16 with gateway + org-conditioned interface
+// endpoints.
+func (s *Stack) singleVPCTemplate(supernet string) (*cfn.Template, error) {
 	plan, err := Allocate(supernet, nil, defaultAZCount)
 	if err != nil {
 		return nil, fmt.Errorf("allocate network CIDRs: %w", err)
@@ -191,6 +209,221 @@ func orgEndpointPolicy() map[string]any {
 			},
 		},
 	}
+}
+
+// hubSpokeTemplate is the hub-and-spoke topology (ADR 0001 step 3): a shared hub
+// VPC holding the centralized org-conditioned interface endpoints, one private
+// spoke VPC per workload tier, and a Transit Gateway joining them with SEGREGATED
+// per-tier route tables — the routing fact that makes the ground:tier /
+// attest:data-classes isolation real (a spoke's TGW route table carries a route to
+// the hub but NOT to sibling spokes, so cross-tier traffic has no path).
+func (s *Stack) hubSpokeTemplate(supernet string, tiers []string) (*cfn.Template, error) {
+	plan, err := Allocate(supernet, tiers, defaultAZCount)
+	if err != nil {
+		return nil, fmt.Errorf("allocate network CIDRs: %w", err)
+	}
+
+	resources := map[string]any{
+		"TransitGateway": cfn.Resource("AWS::EC2::TransitGateway", map[string]any{
+			"Description": "ground hub-and-spoke transit gateway",
+			// Disable automatic association/propagation: ground manages per-tier route
+			// tables explicitly, so a new attachment must NOT auto-join a shared table
+			// (which would defeat tier isolation).
+			"DefaultRouteTableAssociation": "disable",
+			"DefaultRouteTablePropagation": "disable",
+			"Tags": []map[string]string{
+				cfn.Tag("Name", "ground-tgw"),
+				cfn.Tag("managed-by", "ground"),
+			},
+		}),
+	}
+	outputs := map[string]any{}
+
+	// Hub VPC: holds the centralized interface + gateway endpoints (shared by all
+	// spokes via the TGW), plus its own attachment + route table.
+	hubIDs := s.addVPC(resources, "Hub", plan.Hub, true)
+	addTGWAttachment(resources, "Hub", hubIDs)
+	resources["TGWRouteTableHub"] = tgwRouteTable("Hub")
+	resources["TGWAssocHub"] = tgwAssociation("Hub", "Hub")
+	outputs["HubVpcId"] = map[string]any{
+		"Description": "ID of the shared-services hub VPC",
+		"Value":       ref(hubIDs.vpc),
+		"Export":      map[string]string{"Name": "ground-hub-vpc-id"},
+	}
+
+	// One spoke VPC per tier. Each gets its own TGW route table with a single route
+	// to the hub — and crucially, no route to any sibling spoke. The hub's route
+	// table propagates every spoke (the hub can reach all spokes for shared
+	// endpoints); spoke tables do not propagate each other.
+	for _, sp := range plan.Spokes {
+		tier := sp.Name
+		lid := tierLogicalID(tier)
+		ids := s.addVPC(resources, lid, sp, false)
+		addTGWAttachment(resources, lid, ids)
+
+		// Spoke route table: associate the spoke's attachment, route 0/0-to-hub via
+		// the hub attachment (for shared endpoints), nothing toward siblings.
+		resources["TGWRouteTable"+lid] = tgwRouteTable(lid)
+		resources["TGWAssoc"+lid] = tgwAssociation(lid, lid)
+		resources["TGWRouteToHub"+lid] = cfn.Resource("AWS::EC2::TransitGatewayRoute", map[string]any{
+			"TransitGatewayRouteTableId": ref("TGWRouteTable" + lid),
+			"DestinationCidrBlock":       plan.Hub.CIDR.String(),
+			"TransitGatewayAttachmentId": ref("TGWAttachmentHub"),
+		})
+		// Hub can reach this spoke: a route in the hub table to the spoke CIDR.
+		resources["TGWRouteHubTo"+lid] = cfn.Resource("AWS::EC2::TransitGatewayRoute", map[string]any{
+			"TransitGatewayRouteTableId": ref("TGWRouteTableHub"),
+			"DestinationCidrBlock":       sp.CIDR.String(),
+			"TransitGatewayAttachmentId": ref("TGWAttachment" + lid),
+		})
+		outputs[lid+"VpcId"] = map[string]any{
+			"Description": fmt.Sprintf("ID of the %s spoke VPC", tier),
+			"Value":       ref(ids.vpc),
+		}
+	}
+
+	return &cfn.Template{
+		AWSTemplateFormatVersion: "2010-09-09",
+		Description:              "ground: network foundation (hub-and-spoke) — Transit Gateway with segregated per-tier route tables",
+		Parameters: map[string]any{
+			"OrgId": map[string]any{
+				"Type":           "String",
+				"Description":    "AWS Organizations ID (e.g., o-abcd1234). Retrieved automatically by 'ground deploy'.",
+				"AllowedPattern": "^o-[a-z0-9]{10,32}$",
+			},
+		},
+		Resources: resources,
+		Outputs:   outputs,
+	}, nil
+}
+
+// vpcLogicalIDs holds the logical IDs of a VPC block's key resources, so the TGW
+// wiring can reference them.
+type vpcLogicalIDs struct {
+	vpc        string
+	routeTable string
+	subnets    []string
+}
+
+// addVPC writes a private VPC block (VPC, private route table, per-AZ subnets +
+// associations) into resources under the given prefix, and — when withEndpoints —
+// the gateway + org-conditioned interface endpoints. Returns the logical IDs.
+func (s *Stack) addVPC(resources map[string]any, prefix string, alloc VPCAlloc, withEndpoints bool) vpcLogicalIDs {
+	vpcID := prefix + "VPC"
+	rtID := prefix + "PrivateRouteTable"
+	resources[vpcID] = cfn.Resource("AWS::EC2::VPC", map[string]any{
+		"CidrBlock":          alloc.CIDR.String(),
+		"EnableDnsSupport":   true,
+		"EnableDnsHostnames": true,
+		"Tags": []map[string]string{
+			cfn.Tag("Name", "ground-"+strings.ToLower(prefix)),
+			cfn.Tag("managed-by", "ground"),
+		},
+	})
+	resources[rtID] = cfn.Resource("AWS::EC2::RouteTable", map[string]any{
+		"VpcId": ref(vpcID),
+		"Tags": []map[string]string{
+			cfn.Tag("Name", "ground-"+strings.ToLower(prefix)+"-private"),
+			cfn.Tag("managed-by", "ground"),
+		},
+	})
+
+	ids := vpcLogicalIDs{vpc: vpcID, routeTable: rtID}
+	subnetRefs := make([]any, 0, len(alloc.Subnets))
+	for az, subnet := range alloc.Subnets {
+		sid := fmt.Sprintf("%sPrivateSubnet%d", prefix, az+1)
+		resources[sid] = cfn.Resource("AWS::EC2::Subnet", map[string]any{
+			"VpcId":     ref(vpcID),
+			"CidrBlock": subnet.String(),
+			"AvailabilityZone": map[string]any{
+				"Fn::Select": []any{az, map[string]any{"Fn::GetAZs": ""}},
+			},
+			"MapPublicIpOnLaunch": false,
+			"Tags": []map[string]string{
+				cfn.Tag("Name", fmt.Sprintf("ground-%s-private-%d", strings.ToLower(prefix), az+1)),
+				cfn.Tag("managed-by", "ground"),
+			},
+		})
+		resources[sid+"RTAssoc"] = cfn.Resource("AWS::EC2::SubnetRouteTableAssociation", map[string]any{
+			"SubnetId":     ref(sid),
+			"RouteTableId": ref(rtID),
+		})
+		ids.subnets = append(ids.subnets, sid)
+		subnetRefs = append(subnetRefs, ref(sid))
+	}
+
+	if withEndpoints {
+		for _, svc := range sortedUnique(s.cfg.VPCEndpoints) {
+			epID := prefix + endpointLogicalID(svc)
+			if gatewayEndpointServices[svc] {
+				resources[epID] = cfn.Resource("AWS::EC2::VPCEndpoint", map[string]any{
+					"VpcId":           ref(vpcID),
+					"ServiceName":     serviceName(svc, s.org.Region),
+					"VpcEndpointType": "Gateway",
+					"RouteTableIds":   []any{ref(rtID)},
+				})
+				continue
+			}
+			resources[epID] = cfn.Resource("AWS::EC2::VPCEndpoint", map[string]any{
+				"VpcId":             ref(vpcID),
+				"ServiceName":       serviceName(svc, s.org.Region),
+				"VpcEndpointType":   "Interface",
+				"PrivateDnsEnabled": true,
+				"SubnetIds":         subnetRefs,
+				"PolicyDocument":    orgEndpointPolicy(),
+			})
+		}
+	}
+	return ids
+}
+
+// addTGWAttachment attaches a VPC's private subnets to the Transit Gateway.
+func addTGWAttachment(resources map[string]any, prefix string, ids vpcLogicalIDs) {
+	subnetRefs := make([]any, 0, len(ids.subnets))
+	for _, sid := range ids.subnets {
+		subnetRefs = append(subnetRefs, ref(sid))
+	}
+	resources["TGWAttachment"+prefix] = cfn.Resource("AWS::EC2::TransitGatewayAttachment", map[string]any{
+		"TransitGatewayId": ref("TransitGateway"),
+		"VpcId":            ref(ids.vpc),
+		"SubnetIds":        subnetRefs,
+		"Tags": []map[string]string{
+			cfn.Tag("Name", "ground-tgw-attach-"+strings.ToLower(prefix)),
+			cfn.Tag("managed-by", "ground"),
+		},
+	})
+}
+
+// tgwRouteTable builds a segregated Transit Gateway route table for a tier.
+func tgwRouteTable(prefix string) map[string]any {
+	return cfn.Resource("AWS::EC2::TransitGatewayRouteTable", map[string]any{
+		"TransitGatewayId": ref("TransitGateway"),
+		"Tags": []map[string]string{
+			cfn.Tag("Name", "ground-tgw-rt-"+strings.ToLower(prefix)),
+			cfn.Tag("managed-by", "ground"),
+		},
+	})
+}
+
+// tgwAssociation associates a tier's attachment with its own route table.
+func tgwAssociation(rtPrefix, attachPrefix string) map[string]any {
+	return cfn.Resource("AWS::EC2::TransitGatewayRouteTableAssociation", map[string]any{
+		"TransitGatewayRouteTableId": ref("TGWRouteTable" + rtPrefix),
+		"TransitGatewayAttachmentId": ref("TGWAttachment" + attachPrefix),
+	})
+}
+
+// tierLogicalID turns a tier name into a CloudFormation-safe logical ID prefix,
+// e.g. "DoD-CMMC" → "SpokeDoDCMMC".
+func tierLogicalID(tier string) string {
+	var b strings.Builder
+	b.WriteString("Spoke")
+	for _, r := range tier {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 func ref(logicalID string) map[string]string { return map[string]string{"Ref": logicalID} }

--- a/internal/stack/network/network_test.go
+++ b/internal/stack/network/network_test.go
@@ -188,3 +188,131 @@ func TestTemplate_Outputs(t *testing.T) {
 		}
 	}
 }
+
+// hubSpokeStack returns a TransitGateway:true stack with three workload tiers.
+func hubSpokeStack() *Stack {
+	return New(
+		&config.NetworkConfig{
+			CIDRBlock:      "10.0.0.0/8",
+			TransitGateway: true,
+			VPCEndpoints:   []string{"s3", "sts", "ssm"},
+		},
+		&config.OrgConfig{
+			Region:       "us-west-2",
+			ManagementID: "123456789012",
+			WorkloadOUs:  []string{"research", "sensitive", "sandbox"},
+		},
+	)
+}
+
+func TestHubSpoke_TopologyShape(t *testing.T) {
+	res := resourcesByType(t, hubSpokeStack())
+
+	if n := len(res["AWS::EC2::TransitGateway"]); n != 1 {
+		t.Fatalf("got %d transit gateways, want 1", n)
+	}
+	// 1 hub + 3 spokes = 4 VPCs.
+	if n := len(res["AWS::EC2::VPC"]); n != 4 {
+		t.Errorf("got %d VPCs, want 4 (hub + 3 spokes)", n)
+	}
+	// 4 TGW attachments (one per VPC).
+	if n := len(res["AWS::EC2::TransitGatewayAttachment"]); n != 4 {
+		t.Errorf("got %d TGW attachments, want 4", n)
+	}
+	// 4 segregated TGW route tables (hub + per spoke).
+	if n := len(res["AWS::EC2::TransitGatewayRouteTable"]); n != 4 {
+		t.Errorf("got %d TGW route tables, want 4 (segregated per tier)", n)
+	}
+	// No Internet Gateway anywhere.
+	if n := len(res["AWS::EC2::InternetGateway"]); n != 0 {
+		t.Errorf("got %d internet gateways, want 0 (private-only)", n)
+	}
+}
+
+func TestHubSpoke_DisablesDefaultTGWTables(t *testing.T) {
+	res := resourcesByType(t, hubSpokeStack())
+	tgw := res["AWS::EC2::TransitGateway"][0]
+	if tgw["DefaultRouteTableAssociation"] != "disable" {
+		t.Error("TGW must disable default route-table association (else a new attachment auto-joins a shared table, breaking tier isolation)")
+	}
+	if tgw["DefaultRouteTablePropagation"] != "disable" {
+		t.Error("TGW must disable default route-table propagation")
+	}
+}
+
+// The isolation invariant: a spoke's TGW route table has a route to the hub but
+// NEVER to a sibling spoke. This is the routing fact behind tier isolation.
+func TestHubSpoke_NoCrossSpokeRoutes(t *testing.T) {
+	tmpl, err := hubSpokeStack().Template()
+	if err != nil {
+		t.Fatalf("Template: %v", err)
+	}
+
+	// Spoke CIDRs (10.2/16 research?, order is sorted: research, sandbox, sensitive
+	// → 10.1, 10.2, 10.3). Collect every TransitGatewayRoute and check no spoke
+	// route table points at another spoke's CIDR.
+	spokeCIDRs := map[string]bool{"10.1.0.0/16": true, "10.2.0.0/16": true, "10.3.0.0/16": true}
+
+	for logicalID, raw := range tmpl.Resources {
+		r := raw.(map[string]any)
+		if r["Type"] != "AWS::EC2::TransitGatewayRoute" {
+			continue
+		}
+		props := r["Properties"].(map[string]any)
+		rtRef := props["TransitGatewayRouteTableId"].(map[string]string)["Ref"]
+		dest := props["DestinationCidrBlock"].(string)
+
+		// A route living in a spoke route table (TGWRouteTableSpoke*) must target the
+		// hub CIDR (10.0.0.0/16), never a sibling spoke CIDR.
+		if strings.HasPrefix(rtRef, "TGWRouteTableSpoke") {
+			if spokeCIDRs[dest] {
+				t.Errorf("%s: spoke route table %s has a route to spoke CIDR %s — cross-tier path must not exist",
+					logicalID, rtRef, dest)
+			}
+			if dest != "10.0.0.0/16" {
+				t.Errorf("%s: spoke route %s points at %s, expected only the hub CIDR 10.0.0.0/16", logicalID, rtRef, dest)
+			}
+		}
+	}
+}
+
+// Endpoints live only on the hub (shared via TGW); spokes carry none.
+func TestHubSpoke_EndpointsOnlyOnHub(t *testing.T) {
+	tmpl, err := hubSpokeStack().Template()
+	if err != nil {
+		t.Fatalf("Template: %v", err)
+	}
+	for logicalID, raw := range tmpl.Resources {
+		if raw.(map[string]any)["Type"] != "AWS::EC2::VPCEndpoint" {
+			continue
+		}
+		if !strings.HasPrefix(logicalID, "Hub") {
+			t.Errorf("VPC endpoint %s is not on the hub — endpoints are centralized on the hub and shared via TGW", logicalID)
+		}
+	}
+}
+
+func TestHubSpoke_Deterministic(t *testing.T) {
+	a, _ := hubSpokeStack().Template()
+	b, _ := hubSpokeStack().Template()
+	aj, _ := a.JSON()
+	bj, _ := b.JSON()
+	if aj != bj {
+		t.Error("hub-and-spoke template is not deterministic")
+	}
+}
+
+// TransitGateway:true but no workload tiers → degrade to the single-VPC path.
+func TestHubSpoke_DegradesWithoutTiers(t *testing.T) {
+	s := New(
+		&config.NetworkConfig{CIDRBlock: "10.0.0.0/8", TransitGateway: true},
+		&config.OrgConfig{Region: "us-east-1"}, // no WorkloadOUs
+	)
+	res := resourcesByType(t, s)
+	if len(res["AWS::EC2::TransitGateway"]) != 0 {
+		t.Error("no workload tiers → should degrade to single VPC (no TGW)")
+	}
+	if len(res["AWS::EC2::VPC"]) != 1 {
+		t.Errorf("got %d VPCs, want 1 (single-VPC degrade)", len(res["AWS::EC2::VPC"]))
+	}
+}


### PR DESCRIPTION
Build **step 3** of ground's network foundation (`docs/adr/0001-network-foundation.md`) — the topology where tier isolation stops being just a tag and becomes a **routing fact**.

## What
When `network.transit_gateway` is set and `org.workload_ous` lists tiers, `Template()` builds:
- a shared **hub** VPC holding the centralized gateway + org-conditioned interface endpoints (cost: one set shared via TGW, not per-spoke),
- one private **spoke** VPC per workload tier,
- a **Transit Gateway** with **segregated per-tier route tables**.

## The isolation invariant
Each spoke's TGW route table has a route **to the hub** (so it can reach the shared endpoints) and **none to any sibling spoke** — so a SensitiveResearch spoke physically cannot route to a Research spoke. The TGW also **disables default route-table association/propagation**, so a newly-attached VPC can't silently join a shared table and defeat the segregation. `TestHubSpoke_NoCrossSpokeRoutes` asserts no spoke route table ever points at a sibling's CIDR.

## Structure
- `singleVPCTemplate` (step 2) is **unchanged** and remains the degrade path; `Template()` dispatches on config (TGW off or no tiers → single VPC). `TestHubSpoke_DegradesWithoutTiers` covers it.
- Spoke tiers come from `org.WorkloadOUs` — config-driven, deterministic via the step-1 CIDR allocator.
- Helpers: `addVPC` / `addTGWAttachment` / `tgwRouteTable` / `tgwAssociation`.

## Tested (template-as-data, no AWS)
Topology shape (hub + 3 spokes = 4 VPCs, 4 attachments, 4 segregated route tables, **no IGW**), the no-cross-spoke-route invariant, default-table-disable guard, endpoints-only-on-hub, determinism, and degrade-without-tiers. Verified `ground deploy --dry-run` renders the hub-and-spoke CloudFormation (1 TGW, 6 TGW routes = 3 hub→spoke + 3 spoke→hub, 3 endpoints on the hub). Full ground suite: 0 failures.

## Remaining
Step 4 — compute-to-data egress per `DataEndpoint` (the ground#10 routing). And the live numbered-deploy-phase wiring (dry-run only today) is still a follow-up.

Refs: provabl#11, provabl/ground#10.