### PR TITLE
feat(network): compute-to-data egress per DataEndpoint (ADR 0001 step 4, ground#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **Compute-to-data egress per `DataEndpoint`** (`internal/stack/network/network.go`) — build step 4 of
+  ADR 0001, the routing half of provabl/ground#10 (and its final piece). For each declared
+  `network.data_endpoints` entry, the hub-and-spoke template now renders a hub-side scoped egress path
+  whose mechanism is inferred from the endpoint URL: an **S3 host** (dbGaP) → an S3 **gateway endpoint**
+  on the hub route table (reusing the foundation S3 endpoint when one already exists — a route table
+  permits only one); a **`com.amazonaws.*` PrivateLink** service (AnVIL/Terra) → an **interface
+  endpoint**; **any other (public) host → no route at all**, only a `ground-meta`/output declaration
+  with a warning — ground refuses to route controlled data over a public IGW. This is the network gate
+  that joins the SCP (`data_endpoint_access_scp`) and attest's dataset-scoped Cedar policy (attest#100):
+  who-may-call, who-may-read-which-dataset, and now is-there-a-scoped-backbone-path. Unit-tested
+  (classifier + all three render paths + the S3-reuse dedup); verified via `--dry-run`. **Completes the
+  compute-to-data chain end to end** (provabl ADR 0002 + ground ADR 0001).
 - **Network foundation: hub-and-spoke + Transit Gateway** (`internal/stack/network/network.go`) — build
   step 3 of ADR 0001. When `network.transit_gateway` is set and `org.workload_ous` lists tiers,
   `Template()` now builds a shared **hub** VPC (holding the centralized gateway + org-conditioned

--- a/internal/stack/network/network.go
+++ b/internal/stack/network/network.go
@@ -282,6 +282,13 @@ func (s *Stack) hubSpokeTemplate(supernet string, tiers []string) (*cfn.Template
 		}
 	}
 
+	// Compute-to-data egress (ADR 0001 step 4, provabl/ground#10). For each declared
+	// DataEndpoint, render a hub-side scoped egress path (spokes reach it via the
+	// TGW). The mechanism is inferred from the endpoint URL; a public host that
+	// can't be reached on the AWS backbone gets NO route — never a public IGW for
+	// controlled data (the declaration still ships in ground-meta with a warning).
+	s.addDataEndpointEgress(resources, outputs, hubIDs)
+
 	return &cfn.Template{
 		AWSTemplateFormatVersion: "2010-09-09",
 		Description:              "ground: network foundation (hub-and-spoke) — Transit Gateway with segregated per-tier route tables",
@@ -295,6 +302,112 @@ func (s *Stack) hubSpokeTemplate(supernet string, tiers []string) (*cfn.Template
 		Resources: resources,
 		Outputs:   outputs,
 	}, nil
+}
+
+// egressMechanism is how a DataEndpoint is reached over the AWS backbone.
+type egressMechanism int
+
+const (
+	egressS3Gateway   egressMechanism = iota // S3-host → S3 gateway endpoint
+	egressInterface                          // com.amazonaws.* PrivateLink → interface endpoint
+	egressUnreachable                        // public host with no backbone path → no route
+)
+
+// classifyEndpoint infers the egress mechanism from a DataEndpoint URL. dbGaP
+// lives in S3 (url: s3.amazonaws.com / *.s3.*.amazonaws.com); AnVIL/Terra and
+// similar expose a com.amazonaws.* PrivateLink service name. Anything else is an
+// ordinary public host we refuse to route controlled data to.
+func classifyEndpoint(url string) egressMechanism {
+	u := strings.ToLower(strings.TrimSpace(url))
+	switch {
+	case strings.HasPrefix(u, "com.amazonaws."):
+		return egressInterface
+	case strings.HasPrefix(u, "s3.") || strings.Contains(u, ".s3."):
+		// s3.amazonaws.com, s3.<region>.amazonaws.com, <bucket>.s3.<region>...
+		return egressS3Gateway
+	default:
+		return egressUnreachable
+	}
+}
+
+// addDataEndpointEgress renders the hub-side egress path for each declared
+// DataEndpoint. S3-backed endpoints reuse a single S3 gateway endpoint on the hub
+// route table (a route table allows only one); PrivateLink endpoints get an
+// interface endpoint. Unreachable (public) endpoints get no route — the
+// declaration still ships in ground-meta (with the warning ground emits there).
+func (s *Stack) addDataEndpointEgress(resources, outputs map[string]any, hub vpcLogicalIDs) {
+	// An S3 gateway endpoint may already exist on the hub route table (if "s3" is in
+	// VPCEndpoints). Detect it so we don't add a conflicting second one.
+	s3GatewayExists := false
+	for _, svc := range s.cfg.VPCEndpoints {
+		if svc == "s3" {
+			s3GatewayExists = true
+			break
+		}
+	}
+
+	for _, ep := range s.cfg.DataEndpoints {
+		if ep.Name == "" {
+			continue
+		}
+		lid := "DataEgress" + sanitizeLogical(ep.Name)
+		switch classifyEndpoint(ep.URL) {
+		case egressS3Gateway:
+			if s3GatewayExists {
+				// The hub's foundation S3 gateway endpoint already provides the path;
+				// the dataset is reached through it. Record the binding as an output
+				// rather than a duplicate endpoint.
+				outputs[lid] = map[string]any{
+					"Description": fmt.Sprintf("compute-to-data %q (S3): reached via the hub S3 gateway endpoint", ep.Name),
+					"Value":       ep.URL,
+				}
+				continue
+			}
+			resources[lid] = cfn.Resource("AWS::EC2::VPCEndpoint", map[string]any{
+				"VpcId":           ref(hub.vpc),
+				"ServiceName":     serviceName("s3", s.org.Region),
+				"VpcEndpointType": "Gateway",
+				"RouteTableIds":   []any{ref(hub.routeTable)},
+			})
+			s3GatewayExists = true // subsequent S3 datasets reuse it
+		case egressInterface:
+			resources[lid] = cfn.Resource("AWS::EC2::VPCEndpoint", map[string]any{
+				"VpcId":             ref(hub.vpc),
+				"ServiceName":       ep.URL, // a com.amazonaws.* PrivateLink service name
+				"VpcEndpointType":   "Interface",
+				"PrivateDnsEnabled": false, // partner PrivateLink — no private DNS override
+				"SubnetIds":         hubSubnetRefs(hub),
+				"PolicyDocument":    orgEndpointPolicy(),
+			})
+		case egressUnreachable:
+			// No route. ground-meta still carries the declaration (with a warning);
+			// surfacing it as an output makes the no-route decision visible in the
+			// template too.
+			outputs[lid] = map[string]any{
+				"Description": fmt.Sprintf("compute-to-data %q (%s): NO backbone route — public host; declared in ground-meta only", ep.Name, ep.URL),
+				"Value":       "no-route",
+			}
+		}
+	}
+}
+
+func hubSubnetRefs(hub vpcLogicalIDs) []any {
+	out := make([]any, 0, len(hub.subnets))
+	for _, sid := range hub.subnets {
+		out = append(out, ref(sid))
+	}
+	return out
+}
+
+// sanitizeLogical strips a slug to CloudFormation-safe logical-ID characters.
+func sanitizeLogical(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // vpcLogicalIDs holds the logical IDs of a VPC block's key resources, so the TGW

--- a/internal/stack/network/network_test.go
+++ b/internal/stack/network/network_test.go
@@ -316,3 +316,104 @@ func TestHubSpoke_DegradesWithoutTiers(t *testing.T) {
 		t.Errorf("got %d VPCs, want 1 (single-VPC degrade)", len(res["AWS::EC2::VPC"]))
 	}
 }
+
+func TestClassifyEndpoint(t *testing.T) {
+	cases := map[string]egressMechanism{
+		"s3.amazonaws.com":                           egressS3Gateway,
+		"s3.us-west-2.amazonaws.com":                 egressS3Gateway,
+		"my-dbgap-bucket.s3.us-west-2.amazonaws.com": egressS3Gateway,
+		"com.amazonaws.vpce.us-west-2.vpce-svc-123":  egressInterface,
+		"dtn.ncbi.nlm.nih.gov":                       egressUnreachable,
+		"storage.googleapis.com":                     egressUnreachable,
+	}
+	for url, want := range cases {
+		if got := classifyEndpoint(url); got != want {
+			t.Errorf("classifyEndpoint(%q) = %d, want %d", url, got, want)
+		}
+	}
+}
+
+// dataEndpointStack is a hub-spoke stack with one S3-backed, one PrivateLink, and
+// one public (unreachable) data endpoint. "s3" is NOT in VPCEndpoints, so the
+// S3-backed dataset must create its own gateway endpoint.
+func dataEndpointStack() *Stack {
+	return New(
+		&config.NetworkConfig{
+			CIDRBlock:      "10.0.0.0/8",
+			TransitGateway: true,
+			VPCEndpoints:   []string{"sts", "ssm"}, // no s3 here on purpose
+			DataEndpoints: []config.DataEndpoint{
+				{Name: "ncbi-dbgap", URL: "s3.us-west-2.amazonaws.com", DataClass: "GENOMIC"},
+				{Name: "anvil-terra", URL: "com.amazonaws.vpce.us-west-2.vpce-svc-abc", DataClass: "GENOMIC"},
+				{Name: "public-portal", URL: "dtn.ncbi.nlm.nih.gov", DataClass: "GENOMIC"},
+			},
+		},
+		&config.OrgConfig{Region: "us-west-2", ManagementID: "123456789012", WorkloadOUs: []string{"research"}},
+	)
+}
+
+func TestDataEgress_S3BackedCreatesGatewayEndpoint(t *testing.T) {
+	tmpl, err := dataEndpointStack().Template()
+	if err != nil {
+		t.Fatalf("Template: %v", err)
+	}
+	ep, ok := tmpl.Resources["DataEgressncbidbgap"].(map[string]any)
+	if !ok {
+		t.Fatal("missing DataEgressncbidbgap endpoint (S3-backed dataset should create a gateway endpoint when no foundation S3 endpoint exists)")
+	}
+	props := ep["Properties"].(map[string]any)
+	if props["VpcEndpointType"] != "Gateway" {
+		t.Errorf("S3 data endpoint type = %v, want Gateway", props["VpcEndpointType"])
+	}
+}
+
+func TestDataEgress_PrivateLinkInterface(t *testing.T) {
+	tmpl, _ := dataEndpointStack().Template()
+	ep, ok := tmpl.Resources["DataEgressanvilterra"].(map[string]any)
+	if !ok {
+		t.Fatal("missing DataEgressanvilterra interface endpoint")
+	}
+	props := ep["Properties"].(map[string]any)
+	if props["VpcEndpointType"] != "Interface" {
+		t.Errorf("PrivateLink endpoint type = %v, want Interface", props["VpcEndpointType"])
+	}
+	if props["ServiceName"] != "com.amazonaws.vpce.us-west-2.vpce-svc-abc" {
+		t.Errorf("ServiceName = %v, want the declared PrivateLink service name", props["ServiceName"])
+	}
+}
+
+// A public host must NOT produce a route resource — only a no-route output.
+func TestDataEgress_PublicHostGetsNoRoute(t *testing.T) {
+	tmpl, _ := dataEndpointStack().Template()
+	if _, exists := tmpl.Resources["DataEgresspublicportal"]; exists {
+		t.Error("public host must not produce an egress endpoint resource (no public IGW for controlled data)")
+	}
+	out, ok := tmpl.Outputs["DataEgresspublicportal"].(map[string]any)
+	if !ok {
+		t.Fatal("expected a no-route output for the public endpoint")
+	}
+	if out["Value"] != "no-route" {
+		t.Errorf("public endpoint output value = %v, want no-route", out["Value"])
+	}
+}
+
+// When the foundation already creates an S3 gateway endpoint (s3 in VPCEndpoints),
+// an S3-backed dataset must reuse it, not add a conflicting second one.
+func TestDataEgress_ReusesFoundationS3Endpoint(t *testing.T) {
+	s := New(
+		&config.NetworkConfig{
+			CIDRBlock:      "10.0.0.0/8",
+			TransitGateway: true,
+			VPCEndpoints:   []string{"s3"}, // foundation S3 gateway endpoint exists
+			DataEndpoints:  []config.DataEndpoint{{Name: "ncbi-dbgap", URL: "s3.us-west-2.amazonaws.com"}},
+		},
+		&config.OrgConfig{Region: "us-west-2", WorkloadOUs: []string{"research"}},
+	)
+	tmpl, _ := s.Template()
+	if _, exists := tmpl.Resources["DataEgressncbidbgap"]; exists {
+		t.Error("S3 dataset must reuse the foundation S3 gateway endpoint, not create a second (a route table allows only one S3 gateway endpoint)")
+	}
+	if _, ok := tmpl.Outputs["DataEgressncbidbgap"]; !ok {
+		t.Error("expected an output recording the dataset is reached via the hub S3 gateway endpoint")
+	}
+}


### PR DESCRIPTION
Build **step 4** of ground's network foundation — the **final piece of ground#10** and the compute-to-data chain (provabl ADR 0002 + ground ADR 0001).

## What
For each declared `network.data_endpoints` entry, the hub-and-spoke template renders a hub-side scoped egress path. The mechanism is **inferred from the endpoint URL**:

| URL shape | Mechanism | Example |
|---|---|---|
| S3 host | S3 **gateway endpoint** on the hub route table (reuses the foundation S3 endpoint if present — a route table allows only one) | dbGaP `s3.us-west-2.amazonaws.com` |
| `com.amazonaws.*` PrivateLink | **interface endpoint** | AnVIL/Terra VPCE service |
| any other (public) host | **no route** — only a `ground-meta`/output declaration + warning | `dtn.ncbi.nlm.nih.gov` |

**ground refuses to route controlled data over a public IGW** — an unreachable endpoint is declared, not routed.

## The third gate
This completes the three-layer model: the SCP (`data_endpoint_access_scp`) gates *who may call*, attest's dataset-scoped Cedar policy (attest#100) gates *who may read which dataset with which DUA*, and this egress path provides *a scoped backbone route to reach it*.

## Tested (template-as-data, no AWS)
`classifyEndpoint` (S3 / PrivateLink / public), all three render paths (S3 gateway, PrivateLink interface, public→no-route-output), and the foundation-S3-reuse dedup (no conflicting second gateway endpoint). Verified `ground deploy --dry-run` renders the dbGaP egress endpoint. Full ground suite: 0 failures.

## Scope notes
- `DataEndpoint` carries no bucket ARNs, so the S3 gateway endpoint isn't yet bucket-scoped via an endpoint policy — a refinement for when the config grows that field. The dataset-level authorization is already enforced by attest's Cedar policy.
- Live numbered-deploy-phase wiring (the network stack is dry-run-only today) remains the one open follow-up on this stack.

With this, **ground#10 is fully implemented** and the compute-to-data chain is complete end to end. Refs: provabl#11, provabl/ground#10.