### PR TITLE
feat(deploy): wire network stack into ground deploy; unify deploy phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
   the live IAM simulator (forging/stripping `attest:pcr0`/`attest:pcr7` → explicitDeny); see
   `policies/SECURITY.md`.
 
+### Changed
+
+- **`ground deploy` wires in the network stack as a real deploy phase** and unifies the deploy
+  sequence. Previously the network foundation was `--dry-run`-visible only, and the live deploy
+  hardcoded brittle phase numbering (`[1/2]` then `[3/4]`/`[4/4]` split across an ad-hoc block and a
+  loop). Now all five stacks (logging → security → accounts → identity → network) deploy through one
+  ordered loop with consistent `[i/5]` numbering. The network stack's `OrgId` parameter (for its
+  org-conditioned endpoint policy) is auto-filled via `organizations:DescribeOrganization`, the same
+  way the accounts stack fills `OrgRootId` — so the org-conditioned VPC endpoints deploy without a
+  manual parameter. Closes the deploy-wiring follow-up left by ADR 0001 steps 2–4.
+
 ### Added
 
 - **Compute-to-data egress per `DataEndpoint`** (`internal/stack/network/network.go`) — build step 4 of

--- a/cmd/ground/main.go
+++ b/cmd/ground/main.go
@@ -14,6 +14,7 @@ import (
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	"github.com/provabl/ground/internal/cfn"
 	"github.com/provabl/ground/internal/config"
 	"github.com/provabl/ground/internal/deploy"
 	"github.com/provabl/ground/internal/iac"
@@ -195,13 +196,27 @@ func runDeploy(configPath, region string, dryRun bool) error {
 	accountsTmpl, _ := accountsStack.Template()
 	identityTmpl, _ := identityStack.Template()
 
-	// Network foundation (single VPC; ADR 0001 step 2). Generated for dry-run
-	// visibility. Live deploy wiring (a 5th numbered phase) is a follow-up; the
-	// hub-and-spoke + Transit Gateway expansion is ADR 0001 step 3.
+	// Network foundation (ADR 0001). Single-VPC or hub-and-spoke per config.
 	netStack := network.New(&cfg.Network, &cfg.Org)
 	netTmpl, err := netStack.Template()
 	if err != nil {
 		return fmt.Errorf("generate network template: %w", err)
+	}
+	// Inject the OrgId parameter (org-conditioned endpoint policy) the same way the
+	// accounts stack gets OrgRootId — discovered via the Organizations API.
+	if netTmpl.Parameters != nil {
+		if _, hasOrgID := netTmpl.Parameters["OrgId"]; hasOrgID {
+			orgID, orgErr := fetchOrgID(context.Background(), cfg.Org.Region)
+			if orgErr != nil {
+				fmt.Printf("  ⚠ Could not auto-discover org ID: %v\n", orgErr)
+				fmt.Println("  Retrieve manually: aws organizations describe-organization --query 'Organization.Id' --output text")
+			} else if orgID != "" {
+				if p, ok := netTmpl.Parameters["OrgId"].(map[string]any); ok {
+					p["Default"] = orgID
+				}
+				fmt.Printf("  Org ID: %s\n", orgID)
+			}
+		}
 	}
 
 	// Inject OrgRootId parameter into accounts template.
@@ -250,47 +265,29 @@ func runDeploy(configPath, region string, dryRun bool) error {
 
 	fmt.Printf("Deploying foundation for: %s (region: %s)\n\n", cfg.Org.Name, cfg.Org.Region)
 
-	// Phase 1a: logging foundation.
-	fmt.Printf("  [1/2] %s ... ", logStack.StackName())
-	logJSON, _ := logTmpl.JSON()
-	logResult, err := deployer.Deploy(ctx, logStack.StackName(), logJSON)
-	if err != nil {
-		return fmt.Errorf("deploy %s: %w", logStack.StackName(), err)
-	}
-	action := "updated"
-	if logResult.Created {
-		action = "created"
-	}
-	fmt.Printf("%s (%s)\n", action, logResult.Status)
-
-	// Phase 1b: security baseline.
-	fmt.Printf("  [2/2] %s ... ", secStack.StackName())
-	secJSON, _ := secTmpl.JSON()
-	secResult, err := deployer.Deploy(ctx, secStack.StackName(), secJSON)
-	if err != nil {
-		return fmt.Errorf("deploy %s: %w", secStack.StackName(), err)
-	}
-	action = "updated"
-	if secResult.Created {
-		action = "created"
-	}
-	fmt.Printf("%s (%s)\n", action, secResult.Status)
-
-	fmt.Println("\nPhase 1 complete.")
-
-	// Phase 2: accounts + identity stacks (templates already generated for dry-run above).
-	for _, entry := range []struct {
+	// One ordered deploy sequence with consistent [i/N] numbering. Order matters:
+	// logging + security plumbing first, then the org structure (accounts/identity),
+	// then the network foundation that rides on the org (its endpoint policy needs
+	// the OrgId discovered above).
+	stacks := []struct {
 		name string
-		json string
+		tmpl *cfn.Template
 	}{
-		{accountsStack.StackName(), func() string { j, _ := accountsTmpl.JSON(); return j }()},
-		{identityStack.StackName(), func() string { j, _ := identityTmpl.JSON(); return j }()},
-	} {
-		idx := map[string]string{accountsStack.StackName(): "3", identityStack.StackName(): "4"}[entry.name]
-		fmt.Printf("  [%s/4] %s ... ", idx, entry.name)
-		result, deployErr := deployer.Deploy(ctx, entry.name, entry.json)
+		{logStack.StackName(), logTmpl},
+		{secStack.StackName(), secTmpl},
+		{accountsStack.StackName(), accountsTmpl},
+		{identityStack.StackName(), identityTmpl},
+		{netStack.StackName(), netTmpl},
+	}
+	for i, st := range stacks {
+		fmt.Printf("  [%d/%d] %s ... ", i+1, len(stacks), st.name)
+		body, jsonErr := st.tmpl.JSON()
+		if jsonErr != nil {
+			return fmt.Errorf("serialize %s template: %w", st.name, jsonErr)
+		}
+		result, deployErr := deployer.Deploy(ctx, st.name, body)
 		if deployErr != nil {
-			return fmt.Errorf("deploy %s: %w", entry.name, deployErr)
+			return fmt.Errorf("deploy %s: %w", st.name, deployErr)
 		}
 		verb := "updated"
 		if result.Created {
@@ -371,6 +368,23 @@ func fetchOrgRootID(ctx context.Context, region string) (string, error) {
 		return "", fmt.Errorf("root ID is nil")
 	}
 	return *out.Roots[0].Id, nil
+}
+
+// fetchOrgID returns the AWS Organization ID (o-xxxx), used to fill the network
+// stack's OrgId parameter the same way fetchOrgRootID fills OrgRootId.
+func fetchOrgID(ctx context.Context, region string) (string, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return "", fmt.Errorf("load AWS config: %w", err)
+	}
+	out, err := organizations.NewFromConfig(cfg).DescribeOrganization(ctx, &organizations.DescribeOrganizationInput{})
+	if err != nil {
+		return "", fmt.Errorf("describe organization: %w", err)
+	}
+	if out.Organization == nil || out.Organization.Id == nil {
+		return "", fmt.Errorf("organization ID is nil")
+	}
+	return *out.Organization.Id, nil
 }
 
 func runGenerateIaC(configPath, format string) error {


### PR DESCRIPTION
The deploy-wiring follow-up flagged across ADR 0001 steps 2–4. The network foundation was `--dry-run`-visible only, and the live deploy hardcoded brittle phase numbering (`[1/2]` then `[3/4]`/`[4/4]` split across an ad-hoc block and a loop).

## What changed
- **One ordered deploy loop** for all five stacks (logging → security → accounts → identity → network) with consistent `[i/5]` numbering. Order matters: the network stack rides on the org structure (its endpoint policy needs the discovered `OrgId`), so it deploys last.
- **`fetchOrgID`** (`organizations:DescribeOrganization`) auto-fills the network stack's `OrgId` parameter at deploy time — mirroring how the accounts stack fills `OrgRootId` — so the org-conditioned VPC endpoints deploy without a manual parameter. (The deployer passes no CFN parameters, so injecting a `Default` is how ground threads discovered values into templates.)

## Not a template change
The stack templates are untouched — this is purely the orchestration that makes the network stack actually deploy (and de-brittles the existing phase numbering). Full ground suite: 0 failures; `--dry-run` lists all five stacks.

With this, the network foundation (ADR 0001) is complete **and deployed by `ground deploy`**, not just generated. Refs: provabl#11, provabl/ground#10.