### PR TITLE
feat(policies): split runtime-attestation SCP per kind; README trust-model (ground#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Changed
 
+- **Runtime-attestation SCP split per attestation kind, no conflation** (ground#29; provabl ADR 0003,
+  epic provabl#30). The single `nitro_attestation_scp.json` gated data access on the conflated
+  `attest:nitro-attested` tag — which couldn't distinguish enclave-grade isolation from measured-boot.
+  Replaced with three composable SCPs an operator picks by the grade the data demands:
+  `enclave_attestation_scp.json` (requires `attest:enclave-attested`, written by nitro),
+  `boot_attestation_scp.json` (requires `attest:boot-attested`, written by tpm), and
+  `runtime_attestation_either_scp.json` (one `StringNotEquals` block listing both tags → denies only
+  when *neither* is present, i.e. permit if either). Tests (`TestRuntimeAttestationSCPs`) verify each
+  single-kind SCP gates on its own tag and **not** the other (no conflation), and that the "either"
+  SCP keeps both keys in one statement (separate statements would AND into "require both").
+- **README trust-model section** (audit Tier-1): states the front-door honest limits — ground makes
+  zero compliance claims (attest does, after a scan); SCPs do not restrict the Org management account;
+  the runtime-attestation SCPs are only as strong as the producer (nitro/tpm) that writes their tags.
+
 - **AMI-vetting lockdown SCP now also protects the golden-PCR tags** (provabl#13): `policies/ami_vetting_lockdown_scp.json`
   extends its `aws:TagKeys` condition (now `ForAnyValue:StringLike`) to cover `attest:pcr*` alongside
   `attest:vetted`, so only the vetter can write the golden boot-measurement tags `vet ami-reference`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ Every policy ground deploys is tested before it ships. Permission boundaries, VP
 endpoint policies, and tagging SCPs are verified by policy unit tests — the same
 test-driven approach used across the Provabl suite.
 
+## Trust model — what ground does and does not guarantee
+
+Read this before relying on ground for a compliance claim:
+
+- **ground makes zero compliance claims.** It deploys a *correct foundation* (org
+  structure, network, logging, baseline SCPs). Whether that foundation *satisfies* a
+  framework is **attest**'s judgment, made after `attest scan` — not ground's. ground
+  shipping cleanly is necessary, not sufficient, for compliance.
+- **SCPs do not restrict the Organization management account.** AWS Service Control
+  Policies never apply to the management (payer) account or its root user. Every
+  guardrail ground deploys gates *member* accounts; the management account is governed
+  operationally, not by these SCPs. Run workloads in member accounts, not the root.
+- **The runtime-attestation SCPs gate on tags a producer must write.** The
+  enclave/boot-attestation SCPs deny data access unless `attest:enclave-attested` /
+  `attest:boot-attested` is present — but ground does not *produce* those tags (nitro/tpm
+  do). The gate is only as strong as the producer's attestation and the principal-tag
+  integrity behind it.
+
 ## Status
 
 🚧 **Under active development** — initial CDK stacks being built.

--- a/policies/boot_attestation_scp.json
+++ b/policies/boot_attestation_scp.json
@@ -2,7 +2,7 @@
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "DenyDataAccessWithoutNitroAttestation",
+      "Sid": "DenyDataAccessWithoutBootAttestation",
       "Effect": "Deny",
       "Action": [
         "s3:GetObject",
@@ -15,7 +15,7 @@
       "Resource": "*",
       "Condition": {
         "StringNotEquals": {
-          "aws:PrincipalTag/attest:nitro-attested": "true"
+          "aws:PrincipalTag/attest:boot-attested": "true"
         }
       }
     }

--- a/policies/enclave_attestation_scp.json
+++ b/policies/enclave_attestation_scp.json
@@ -1,0 +1,23 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyDataAccessWithoutEnclaveAttestation",
+      "Effect": "Deny",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "sagemaker:CreateTrainingJob",
+        "sagemaker:CreateNotebookInstance",
+        "sagemaker:CreateProcessingJob",
+        "bedrock:InvokeModel"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringNotEquals": {
+          "aws:PrincipalTag/attest:enclave-attested": "true"
+        }
+      }
+    }
+  ]
+}

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -222,35 +222,91 @@ func TestAccountTaggingHasFiveStatements(t *testing.T) {
 	}
 }
 
-// TestNitroAttestationSCPRequiresAttestedTag verifies the nitro-attestation SCP
-// denies sensitive-data actions unless the principal carries
-// aws:PrincipalTag/attest:nitro-attested == "true". This is the IAM-layer half of
-// the evidence kernel's runtime attestation: the nitro provider produces the
-// verdict, a tag carries it, and this SCP gates data access on it.
-func TestNitroAttestationSCPRequiresAttestedTag(t *testing.T) {
-	p := loadPolicy(t, "nitro_attestation_scp.json")
+// TestRuntimeAttestationSCPs verifies the per-kind runtime-attestation SCPs (the
+// IAM-layer half of the evidence kernel's runtime attestation). Per provabl ADR
+// 0003 (no conflation), the single attest:nitro-attested SCP was split into a
+// per-property pair plus an "either" variant, so an operator can require
+// enclave-grade isolation, measured-boot, or either — distinct trust strengths,
+// not one conflated boolean:
+//   - enclave_attestation_scp.json     → requires attest:enclave-attested (nitro)
+//   - boot_attestation_scp.json        → requires attest:boot-attested    (tpm)
+//   - runtime_attestation_either_scp.json → permit if EITHER tag is "true"
+func TestRuntimeAttestationSCPs(t *testing.T) {
+	sensitiveActions := []string{"s3:GetObject", "sagemaker:CreateTrainingJob"}
 
-	// Fail-closed: the policy must Deny (never Allow — an Allow would be a no-op).
-	if !p.AllDenyStatements() {
-		t.Error("nitro_attestation_scp must use only Deny statements; an Allow would be a no-op")
+	// The two single-kind SCPs: each denies unless its specific tag is present.
+	single := []struct {
+		file string
+		tag  string
+	}{
+		{"enclave_attestation_scp.json", "attest:enclave-attested"},
+		{"boot_attestation_scp.json", "attest:boot-attested"},
 	}
-
-	// The gating condition must be present.
-	if !hasNitroAttestationCondition(p) {
-		t.Error("nitro_attestation_scp must deny on StringNotEquals aws:PrincipalTag/attest:nitro-attested == \"true\"; " +
-			"without it, an unattested principal can access sensitive data")
-	}
-
-	// The sensitive-data actions must be covered by the gated statement.
-	sensitiveActions := []string{
-		"s3:GetObject",
-		"sagemaker:CreateTrainingJob",
-	}
-	for _, action := range sensitiveActions {
-		if !statementDeniesAction(p, action) {
-			t.Errorf("nitro_attestation_scp does not deny %s — unattested data-access path open", action)
+	for _, tc := range single {
+		p := loadPolicy(t, tc.file)
+		if !p.AllDenyStatements() {
+			t.Errorf("%s must use only Deny statements; an Allow would be a no-op", tc.file)
+		}
+		if !hasPrincipalTagNotEqualsCondition(p, tc.tag) {
+			t.Errorf("%s must deny on StringNotEquals aws:PrincipalTag/%s == \"true\"; "+
+				"without it, an un-attested principal can access sensitive data", tc.file, tc.tag)
+		}
+		for _, action := range sensitiveActions {
+			if !statementDeniesAction(p, action) {
+				t.Errorf("%s does not deny %s — un-attested data-access path open", tc.file, action)
+			}
+		}
+		// No conflation: the enclave SCP must not also accept the boot tag, and vice versa.
+		other := "attest:boot-attested"
+		if tc.tag == "attest:boot-attested" {
+			other = "attest:enclave-attested"
+		}
+		if hasPrincipalTagNotEqualsCondition(p, other) {
+			t.Errorf("%s must NOT reference %s — the per-kind SCPs are deliberately distinct (ADR 0003)", tc.file, other)
 		}
 	}
+
+	// The "either" SCP: a single StringNotEquals block listing BOTH tags ANDs them,
+	// so the Deny fires only when NEITHER is "true" — i.e. permit if either. Both
+	// keys must therefore be present in one statement.
+	either := loadPolicy(t, "runtime_attestation_either_scp.json")
+	if !either.AllDenyStatements() {
+		t.Error("runtime_attestation_either_scp must use only Deny statements")
+	}
+	if !hasPrincipalTagNotEqualsCondition(either, "attest:enclave-attested") ||
+		!hasPrincipalTagNotEqualsCondition(either, "attest:boot-attested") {
+		t.Error("runtime_attestation_either_scp must deny only when BOTH enclave- and boot-attested are absent " +
+			"(one StringNotEquals block with both keys → permit if either)")
+	}
+	if !bothTagsInOneStatement(either, "aws:PrincipalTag/attest:enclave-attested", "aws:PrincipalTag/attest:boot-attested") {
+		t.Error("runtime_attestation_either_scp: both tag keys must be in the SAME StringNotEquals block " +
+			"(separate statements would AND into 'require both', not 'either')")
+	}
+	for _, action := range sensitiveActions {
+		if !statementDeniesAction(either, action) {
+			t.Errorf("runtime_attestation_either_scp does not deny %s", action)
+		}
+	}
+}
+
+// bothTagsInOneStatement reports whether a single Deny statement's StringNotEquals
+// condition lists both tag keys (the "either" idiom — AND inside one block).
+func bothTagsInOneStatement(p *policy.Policy, keyA, keyB string) bool {
+	for _, s := range p.Statements {
+		if s.Effect != "Deny" || s.Condition == nil {
+			continue
+		}
+		cond, ok := s.Condition["StringNotEquals"].(map[string]any)
+		if !ok {
+			continue
+		}
+		_, hasA := cond[keyA]
+		_, hasB := cond[keyB]
+		if hasA && hasB {
+			return true
+		}
+	}
+	return false
 }
 
 // TestAMILaunchGatingSCPDeniesUnvettedAMIs verifies the AMI-launch-gating SCP
@@ -435,11 +491,11 @@ func lockdownHasVetterArnException(p *policy.Policy) bool {
 	return false
 }
 
-// hasNitroAttestationCondition returns true if p has a Deny statement whose
-// Condition is StringNotEquals on aws:PrincipalTag/attest:nitro-attested = "true"
-// (deny unless attested — covers both a missing and a non-"true" tag).
-func hasNitroAttestationCondition(p *policy.Policy) bool {
-	const tagKey = "aws:PrincipalTag/attest:nitro-attested"
+// hasPrincipalTagNotEqualsCondition returns true if p has a Deny statement whose
+// Condition is StringNotEquals on aws:PrincipalTag/<tag> == "true" (deny unless the
+// principal carries the tag — covers both a missing and a non-"true" tag).
+func hasPrincipalTagNotEqualsCondition(p *policy.Policy, tag string) bool {
+	tagKey := "aws:PrincipalTag/" + tag
 	for _, s := range p.Statements {
 		if s.Effect != "Deny" || s.Condition == nil {
 			continue

--- a/policies/runtime_attestation_either_scp.json
+++ b/policies/runtime_attestation_either_scp.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyDataAccessWithoutAnyRuntimeAttestation",
+      "Effect": "Deny",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "sagemaker:CreateTrainingJob",
+        "sagemaker:CreateNotebookInstance",
+        "sagemaker:CreateProcessingJob",
+        "bedrock:InvokeModel"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringNotEquals": {
+          "aws:PrincipalTag/attest:enclave-attested": "true",
+          "aws:PrincipalTag/attest:boot-attested": "true"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Final step of the ADR 0003 no-conflation chain (epic provabl#30): the **consumer** side. The schema (attest#116/qualify#49) and producers (nitro#11 `attest:enclave-attested`, tpm#5 `attest:boot-attested`) landed; this makes ground's SCP gate on the per-kind tags.

## What changed
The single `nitro_attestation_scp.json` gated on the conflated `attest:nitro-attested` — which couldn't distinguish enclave-grade isolation from measured-boot. **Removed it**; replaced with three composable SCPs an operator picks by the grade the data demands:
- **`enclave_attestation_scp.json`** → requires `attest:enclave-attested` (nitro)
- **`boot_attestation_scp.json`** → requires `attest:boot-attested` (tpm)
- **`runtime_attestation_either_scp.json`** → one `StringNotEquals` block listing **both** tags, so the Deny fires only when *neither* is present → permit if either.

## Tests
`TestRuntimeAttestationSCPs` verifies each single-kind SCP gates on its own tag and **not** the other (the no-conflation guard), and that the either-SCP keeps both keys in **one** statement — separate statements would AND into "require both," not "either."

## Also: audit Tier-1 — README trust-model
Adds the front-door honest-limits section the doc audit flagged: ground makes zero compliance claims (attest does, post-scan); **SCPs do not restrict the Org management account**; the runtime SCPs are only as strong as the nitro/tpm producer that writes their tags.

Full ground suite green (0 failures). **This completes epic provabl#30** end to end: registry → producers → consumer. Refs: provabl#30, ground#29.