### PR TITLE
docs: add Mermaid boundary diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Part of the [Provabl](https://provabl.dev) suite:
 ground deploys a correctly-configured AWS organization that attest can manage.
 It makes **zero compliance claims** — attest makes those after `attest scan`.
 
+```mermaid
+flowchart LR
+    cfg["ground.yaml"] --> ground["<b>ground</b><br/>deploy org foundation"]
+    ground --> org["AWS org<br/>accounts · OUs · network · logging · baseline SCPs"]
+    ground --> meta["ground-meta.json"]
+    org -->|"standard AWS Organizations APIs"| attest["<b>attest</b><br/>(attest init → scan → claims)"]
+    meta -->|"optional handoff"| attest
+```
+
 ```bash
 ground deploy --config ground.yaml   # deploy AWS organization foundation
 attest init --region us-east-1        # attest discovers the deployed org


### PR DESCRIPTION
Adds a **boundary diagram** to `ground`'s README — the audit's most consistent gap (no tool had one) and the highest-leverage visual for evaluators.

Shows ground's inputs → what it does → the lowered attribute it produces → who consumes it, per the suite's [per-tool doc template](https://github.com/provabl/provabl/blob/main/docs/guide/per-tool-template.md). GitHub-native Mermaid (no binary asset); render-checked (balanced fences, escaped `&amp;`/`&lt;`). Docs-only.