### PR TITLE
docs: add Install section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ attest apply --approve                # deploy policies to the org
 attest scan                           # NOW we can make compliance claims
 ```
 
+## Install
+
+```bash
+go install github.com/provabl/ground/cmd/ground@latest   # requires Go 1.26.4+
+# or build from a clone: go build ./cmd/ground
+```
+
+**Prerequisites.** Go 1.26.4+, and AWS credentials for the **Organization management account** (ground
+deploys org-wide structure: accounts, OUs, SCPs, logging). It needs Organizations + CloudFormation +
+IAM-Identity-Center permissions — run `ground preflight` to verify the calling principal holds them
+before `ground deploy`. `ground deploy --dry-run` renders every stack as CloudFormation JSON without
+touching AWS.
+
 ## What it deploys
 
 | Layer | Components |


### PR DESCRIPTION
Adds an **Install / prerequisites** section to `ground`'s README — the audit's Tier-3 gap (install was thin on the front door for the evaluator audience). Covers how to get it (`go install` for the CLI / `go get` for the evidence library), Go version, AWS permissions + `preflight`, and any build-tag caveats.